### PR TITLE
fix(ci): inline release workflow, add Tauri build, skip crates.io

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,9 +7,94 @@ on:
 permissions:
   contents: write
   pull-requests: write
-  id-token: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
 
 jobs:
+  release-pr:
+    name: Release PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.NIGHTWATCH_APP_ID }}
+          private-key: ${{ secrets.NIGHTWATCH_APP_PRIVATE_KEY }}
+
+      - name: Run release-plz release-pr
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
   release:
-    uses: nightwatch-astro/.github/.github/workflows/rust-release.yml@main
-    secrets: inherit
+    name: Create Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.NIGHTWATCH_APP_ID }}
+          private-key: ${{ secrets.NIGHTWATCH_APP_PRIVATE_KEY }}
+
+      - name: Run release-plz release
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
+
+  build-installer:
+    name: Build Windows Installer
+    needs: release
+    if: github.event_name == 'push'
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install frontend dependencies
+        run: pnpm install --frozen-lockfile
+        working-directory: frontend
+
+      - name: Build Tauri app
+        uses: tauri-apps/tauri-action@v0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          projectPath: crates/astro-up-gui
+          tauriScript: pnpm tauri
+          tagName: v__VERSION__
+          releaseName: "v__VERSION__"
+          releaseBody: "See CHANGELOG.md for details."
+          releaseDraft: false
+          prerelease: false
+          includeUpdaterJson: true
+          updaterJsonPreferNsis: true

--- a/crates/astro-up-cli/Cargo.toml
+++ b/crates/astro-up-cli/Cargo.toml
@@ -2,6 +2,7 @@
 name = "astro-up-cli"
 version = "0.1.0"
 description = "CLI for astro-up — clap + ratatui astrophotography software manager"
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/astro-up-core/Cargo.toml
+++ b/crates/astro-up-core/Cargo.toml
@@ -2,6 +2,7 @@
 name = "astro-up-core"
 version = "0.1.0"
 description = "Shared library for astro-up — types, detection, download, install, engine"
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/astro-up-gui/Cargo.toml
+++ b/crates/astro-up-gui/Cargo.toml
@@ -2,6 +2,7 @@
 name = "astro-up-gui"
 version = "0.1.0"
 description = "Tauri v2 desktop app for astro-up — astrophotography software manager"
+publish = false
 edition.workspace = true
 license.workspace = true
 repository.workspace = true


### PR DESCRIPTION
## Summary

- Replace shared workflow (`nightwatch-astro/.github`) with inline release jobs
- Remove crates.io publishing — this is a desktop app, not a library
- Add Tauri build step that creates Windows NSIS installer on GitHub Releases
- Set `publish = false` on all three workspace crates

## Release Flow

1. Push to main → release-plz creates version bump PR with changelog
2. Merge release PR → release-plz creates GitHub Release with tag
3. GitHub Release triggers tauri-action → builds Windows installer → uploads to release

## Test Plan

- [ ] release-plz PR job runs without crates.io auth
- [ ] release-plz release job creates GitHub Release without publish
- [ ] tauri-action builds NSIS installer on Windows
- [ ] Installer artifact attached to GitHub Release
