### PR TITLE
refactor(004): remove catalog.offline from CatalogConfig

### DIFF
--- a/crates/astro-up-core/src/config/defaults.rs
+++ b/crates/astro-up-core/src/config/defaults.rs
@@ -8,7 +8,6 @@ impl Default for CatalogConfig {
         Self {
             url: "https://github.com/nightwatch-astro/astro-up-manifests/releases/latest/download/catalog.db".into(),
             cache_ttl: Duration::from_secs(86400), // 24h
-            offline: false,
         }
     }
 }

--- a/crates/astro-up-core/src/config/mod.rs
+++ b/crates/astro-up-core/src/config/mod.rs
@@ -103,11 +103,6 @@ pub(crate) fn set_field(config: &mut AppConfig, key: &str, value: &str) -> Resul
             config.catalog.cache_ttl =
                 parse_duration(value).map_err(|_| parse_err("duration (e.g. 24h, 30s)"))?;
         }
-        "catalog.offline" => {
-            config.catalog.offline = value
-                .parse::<bool>()
-                .map_err(|_| parse_err("boolean (true/false)"))?;
-        }
         "paths.download_dir" => config.paths.download_dir = PathBuf::from(value),
         "paths.cache_dir" => config.paths.cache_dir = PathBuf::from(value),
         "paths.data_dir" => config.paths.data_dir = PathBuf::from(value),
@@ -168,7 +163,6 @@ pub(crate) fn get_field_value(config: &AppConfig, key: &str) -> Option<String> {
         "catalog.cache_ttl" => {
             Some(humantime::format_duration(config.catalog.cache_ttl).to_string())
         }
-        "catalog.offline" => Some(config.catalog.offline.to_string()),
         "paths.download_dir" => Some(config.paths.download_dir.display().to_string()),
         "paths.cache_dir" => Some(config.paths.cache_dir.display().to_string()),
         "paths.data_dir" => Some(config.paths.data_dir.display().to_string()),

--- a/crates/astro-up-core/src/config/model.rs
+++ b/crates/astro-up-core/src/config/model.rs
@@ -50,7 +50,6 @@ pub struct CatalogConfig {
     pub url: String,
     #[garde(custom(validate_positive_duration))]
     pub cache_ttl: Duration,
-    pub offline: bool,
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize, Validate)]

--- a/crates/astro-up-core/tests/config/defaults_test.rs
+++ b/crates/astro-up-core/tests/config/defaults_test.rs
@@ -20,7 +20,6 @@ fn load_config_with_empty_db_returns_defaults() {
         "https://github.com/nightwatch-astro/astro-up-manifests/releases/latest/download/catalog.db"
     );
     assert_eq!(config.catalog.cache_ttl.as_secs(), 86400);
-    assert!(!config.catalog.offline);
     assert_eq!(config.paths.download_dir, paths.download_dir);
     assert_eq!(config.paths.cache_dir, paths.cache_dir);
     assert_eq!(config.paths.data_dir, paths.data_dir);
@@ -77,5 +76,5 @@ fn known_keys_discovers_all_fields() {
     assert!(keys.contains(&"network.timeout".to_string()));
     assert!(keys.contains(&"logging.level".to_string()));
     assert!(keys.contains(&"telemetry.enabled".to_string()));
-    assert_eq!(keys.len(), 15); // 15 leaf fields
+    assert_eq!(keys.len(), 14); // 14 leaf fields
 }

--- a/crates/astro-up-core/tests/config/edge_cases_test.rs
+++ b/crates/astro-up-core/tests/config/edge_cases_test.rs
@@ -64,7 +64,7 @@ fn config_list_empty_db_returns_all_defaults() {
     let config = load_config(&db_path, paths, log_file, &[]).unwrap();
 
     let list = config_list(&config, &[]);
-    assert_eq!(list.len(), 15);
+    assert_eq!(list.len(), 14);
     assert!(list.iter().all(|(_, _, overridden)| !overridden));
 }
 

--- a/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
+++ b/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/astro-up-core/tests/config/defaults_test.rs
-assertion_line: 48
+assertion_line: 52
 expression: value
 ---
 {
@@ -9,7 +9,6 @@ expression: value
       "nanos": 0,
       "secs": 86400
     },
-    "offline": false,
     "url": "https://github.com/nightwatch-astro/astro-up-manifests/releases/latest/download/catalog.db"
   },
   "logging": {


### PR DESCRIPTION
## Summary

- Remove `catalog.offline: bool` from `CatalogConfig` struct, defaults, get/set handlers
- Update tests and snapshots (15 → 14 known config keys)

Dead config — if offline, you can't download software anyway. Implicit offline (use local catalog when network unavailable) is sufficient.

Fixes #118
