### PR TITLE
refactor: add EnumTable derive to Category

### DIFF
--- a/crates/astro-up-core/src/types/software.rs
+++ b/crates/astro-up-core/src/types/software.rs
@@ -1,5 +1,5 @@
 use serde::{Deserialize, Serialize};
-use strum::{Display, EnumIter, EnumString};
+use strum::{Display, EnumIter, EnumString, EnumTable};
 
 use super::backup::BackupConfig;
 use super::checkver::CheckverConfig;
@@ -23,6 +23,7 @@ pub enum SoftwareType {
 
 #[derive(
     Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize, Display, EnumString, EnumIter,
+    EnumTable,
 )]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]


### PR DESCRIPTION
## Summary

- Add `EnumTable` derive to `Category` enum, enabling `CategoryTable<V>` for zero-allocation fixed-size array indexing by category variant

One-line change. Unlocks `CategoryTable<Vec<Software>>` patterns in future catalog grouping code.

Fixes #80
