### PR TITLE
refactor(003): align Software.id with PackageId newtype

### DIFF
--- a/crates/astro-up-core/src/types/software.rs
+++ b/crates/astro-up-core/src/types/software.rs
@@ -1,6 +1,8 @@
 use serde::{Deserialize, Serialize};
 use strum::{Display, EnumIter, EnumString};
 
+use crate::catalog::PackageId;
+
 use super::backup::BackupConfig;
 use super::checkver::CheckverConfig;
 use super::dependency::DependencyConfig;
@@ -42,7 +44,7 @@ pub enum Category {
 /// The central aggregate — a complete software package definition.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct Software {
-    pub id: String,
+    pub id: PackageId,
     #[serde(default)]
     pub slug: String,
     pub name: String,

--- a/crates/astro-up-core/tests/software_serde.rs
+++ b/crates/astro-up-core/tests/software_serde.rs
@@ -69,7 +69,7 @@ category = "capture"
 #[test]
 fn nina_manifest_deserializes() {
     let software: Software = toml::from_str(NINA_TOML).expect("NINA manifest should deserialize");
-    assert_eq!(software.id, "nina-app");
+    assert_eq!(software.id.as_ref(), "nina-app");
     assert_eq!(software.name, "N.I.N.A.");
     assert_eq!(software.category.to_string(), "capture");
     assert_eq!(software.software_type.to_string(), "application");
@@ -104,7 +104,7 @@ fn nina_snapshot() {
 fn minimal_manifest_deserializes() {
     let software: Software =
         toml::from_str(MINIMAL_TOML).expect("minimal manifest should deserialize");
-    assert_eq!(software.id, "test-app");
+    assert_eq!(software.id.as_ref(), "test-app");
     assert!(software.detection.is_none());
     assert!(software.install.is_none());
     assert!(software.checkver.is_none());


### PR DESCRIPTION
## Summary

- Change `Software.id` from `String` to `PackageId` (validated newtype)
- Both `Software.id` and `PackageSummary.id` now use the same type
- Update test assertions to use `.as_ref()` for string comparison

Fixes #161
