### PR TITLE
fix(ci): raise clippy too-many-arguments threshold for EnumTable

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,1 @@
+too-many-arguments-threshold = 12


### PR DESCRIPTION
## Summary

- Add `clippy.toml` with `too-many-arguments-threshold = 12`
- Fixes CI failure caused by `EnumTable` derive on `Category` (10 variants) generating a constructor exceeding clippy's default limit of 7

## Test plan

- [x] `cargo clippy -p astro-up-core -- -D warnings` passes
