### PR TITLE
fix: update error_display test after CoreError cleanup

### DIFF
--- a/crates/astro-up-core/tests/error_display.rs
+++ b/crates/astro-up-core/tests/error_display.rs
@@ -4,7 +4,6 @@ use astro_up_core::types::{CheckMethod, KnownExitCode};
 #[test]
 fn error_messages_are_readable() {
     let errors: Vec<CoreError> = vec![
-        CoreError::NotInstalled,
         CoreError::ChecksumMismatch {
             expected: "abc123".into(),
             actual: "def456".into(),
@@ -31,7 +30,6 @@ fn error_messages_are_readable() {
         CoreError::MissingDependency {
             dep_id: "ascom-platform".into(),
         },
-        CoreError::UnsupportedPlatform,
         CoreError::NotFound {
             input: "nonexistent".into(),
         },

--- a/crates/astro-up-core/tests/snapshots/error_display__error_messages_are_readable.snap
+++ b/crates/astro-up-core/tests/snapshots/error_display__error_messages_are_readable.snap
@@ -1,9 +1,8 @@
 ---
-source: crates/astro-up-core/src/error.rs
-assertion_line: 138
+source: crates/astro-up-core/tests/error_display.rs
+assertion_line: 69
 expression: "errors.iter().map(|e| e.to_string()).collect::<Vec<_>>().join(\"\\n\")"
 ---
-software not installed
 checksum mismatch: expected abc123, got def456
 manifest 'nina-app' invalid: missing detection
 installer failed with exit code 1: package_in_use
@@ -14,7 +13,6 @@ installer busy
 package in use by NINA.exe
 already installed: nina-app 3.1.2
 missing dependency: ascom-platform
-unsupported platform
 not found: nonexistent
 version parse failed for 'not-a-version': invalid format
 provider 'github' unavailable: connection refused


### PR DESCRIPTION
## Summary

- Remove references to deleted `CoreError::NotInstalled` and `CoreError::UnsupportedPlatform` from `error_display.rs` test
- Update snapshot to match

Follow-up to #218 (removed superseded Detector trait).

## Test plan

- [x] 162 tests passing
- [x] `cargo clippy -- -D warnings` clean
