### PR TITLE
test: add missing integration tests and performance benchmarks

### DIFF
--- a/crates/astro-up-core/src/detect/mod.rs
+++ b/crates/astro-up-core/src/detect/mod.rs
@@ -1,4 +1,4 @@
-mod ascom;
+pub mod ascom;
 mod cache;
 mod file;
 pub mod hardware;

--- a/crates/astro-up-core/tests/catalog_performance.rs
+++ b/crates/astro-up-core/tests/catalog_performance.rs
@@ -1,0 +1,78 @@
+//! Performance benchmarks for catalog operations (SC-001, SC-002 from spec 005).
+
+use std::path::Path;
+use std::time::Instant;
+
+use astro_up_core::catalog::SqliteCatalogReader;
+
+fn fixture_catalog() -> std::path::PathBuf {
+    Path::new(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/catalog"
+    ))
+    .join("catalog.db")
+}
+
+/// SC-001: Catalog open should complete in under 10ms.
+#[test]
+fn catalog_open_under_10ms() {
+    let path = fixture_catalog();
+    if !path.exists() {
+        eprintln!("skipping: fixture catalog not found");
+        return;
+    }
+
+    let start = Instant::now();
+    let _reader = SqliteCatalogReader::open(&path).expect("failed to open catalog");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_millis() < 10,
+        "catalog open took {elapsed:?}, expected <10ms (SC-001)"
+    );
+}
+
+/// SC-002: FTS5 search should complete in under 50ms.
+#[tokio::test]
+async fn fts5_search_under_50ms() {
+    let path = fixture_catalog();
+    if !path.exists() {
+        eprintln!("skipping: fixture catalog not found");
+        return;
+    }
+
+    let reader = SqliteCatalogReader::open(&path).expect("failed to open catalog");
+
+    let start = Instant::now();
+    let results = reader.search("nina").expect("search failed");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_millis() < 50,
+        "FTS5 search took {elapsed:?}, expected <50ms (SC-002)"
+    );
+    // Fixture catalog should have at least one result for "nina"
+    assert!(!results.is_empty(), "expected search results for 'nina'");
+}
+
+/// SC-001 related: list_all should complete quickly even for full catalog.
+#[test]
+fn list_all_under_50ms() {
+    let path = fixture_catalog();
+    if !path.exists() {
+        eprintln!("skipping: fixture catalog not found");
+        return;
+    }
+
+    let reader = SqliteCatalogReader::open(&path).expect("failed to open catalog");
+
+    let start = Instant::now();
+    let all = reader.list_all().expect("list_all failed");
+    let elapsed = start.elapsed();
+
+    assert!(
+        elapsed.as_millis() < 50,
+        "list_all took {elapsed:?}, expected <50ms"
+    );
+    assert!(!all.is_empty(), "catalog should not be empty");
+}

--- a/crates/astro-up-core/tests/detect_ascom.rs
+++ b/crates/astro-up-core/tests/detect_ascom.rs
@@ -1,0 +1,44 @@
+use astro_up_core::detect::DetectionResult;
+use astro_up_core::types::{DetectionConfig, DetectionMethod};
+
+fn ascom_config(key: &str) -> DetectionConfig {
+    DetectionConfig {
+        method: DetectionMethod::AscomProfile,
+        registry_key: Some(key.into()),
+        registry_value: None,
+        file_path: None,
+        version_regex: None,
+        product_code: None,
+        upgrade_code: None,
+        inf_provider: None,
+        device_class: None,
+        inf_name: None,
+        fallback: None,
+    }
+}
+
+#[cfg(windows)]
+#[tokio::test]
+async fn ascom_missing_platform_returns_not_installed() {
+    // Most Windows CI runners don't have ASCOM Platform installed
+    // This should return NotInstalled (no HKLM\SOFTWARE\ASCOM key)
+    let config = ascom_config("Camera Drivers/ASCOM.Simulator.Camera");
+    let result = astro_up_core::detect::ascom::detect(&config).await;
+
+    // Either NotInstalled (no ASCOM) or Installed (if ASCOM happens to be there)
+    assert!(matches!(
+        result,
+        DetectionResult::NotInstalled
+            | DetectionResult::Installed { .. }
+            | DetectionResult::InstalledUnknownVersion { .. }
+    ));
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn ascom_returns_unavailable_on_non_windows() {
+    let config = ascom_config("Camera Drivers/ASCOM.Simulator.Camera");
+    let result = astro_up_core::detect::ascom::detect(&config).await;
+
+    assert!(matches!(result, DetectionResult::Unavailable { .. }));
+}

--- a/crates/astro-up-core/tests/detect_hardware.rs
+++ b/crates/astro-up-core/tests/detect_hardware.rs
@@ -1,0 +1,25 @@
+use astro_up_core::detect::hardware::VidPid;
+
+#[cfg(windows)]
+#[tokio::test]
+async fn discover_enumerates_usb_devices() {
+    // On Windows, query Win32_PnPEntity and verify USB devices are found
+    // We can't assert on specific hardware, but we can verify the query doesn't error
+    let patterns: Vec<(VidPid, String)> = vec![];
+    let managed = std::collections::HashSet::new();
+
+    let matches = astro_up_core::detect::hardware::discover(&patterns, &managed).await;
+    // Empty patterns = no matches, but the WMI query should succeed
+    assert!(matches.is_empty());
+}
+
+#[cfg(not(windows))]
+#[tokio::test]
+async fn discover_returns_empty_on_non_windows() {
+    let patterns: Vec<(VidPid, String)> =
+        vec![(VidPid::parse("03C3:*").unwrap(), "zwo-asi-camera".into())];
+    let managed = std::collections::HashSet::new();
+
+    let matches = astro_up_core::detect::hardware::discover(&patterns, &managed).await;
+    assert!(matches.is_empty());
+}

--- a/crates/astro-up-core/tests/detect_performance.rs
+++ b/crates/astro-up-core/tests/detect_performance.rs
@@ -1,0 +1,29 @@
+use std::time::Instant;
+
+use astro_up_core::detect::pe;
+
+/// SC-001 proxy: verify PE detection completes quickly (cross-platform component).
+/// Full scan benchmark requires Windows + real catalog — this validates the
+/// per-package detection path is fast enough.
+#[test]
+fn pe_detection_completes_under_100ms() {
+    let start = Instant::now();
+    // Run PE detection 95 times (simulating full catalog scan)
+    for _ in 0..95 {
+        let _ = pe::read_pe_version_sync("tests/fixtures/test.exe");
+    }
+    let elapsed = start.elapsed();
+
+    // 95 PE reads should complete well under 5 seconds
+    assert!(
+        elapsed.as_secs() < 5,
+        "95 PE detections took {elapsed:?}, expected <5s (SC-001)"
+    );
+
+    // Each individual read should be <50ms
+    let per_read = elapsed / 95;
+    assert!(
+        per_read.as_millis() < 50,
+        "per-read {per_read:?}, expected <50ms"
+    );
+}


### PR DESCRIPTION
## Summary

- Add hardware discovery integration test (Windows + non-Windows stub)
- Add ASCOM Profile integration test (Windows + non-Windows stub)
- Add PE detection performance benchmark (95 reads <5s, SC-001 proxy)
- Add catalog performance benchmarks (open <10ms, FTS5 <50ms, list_all <50ms)
- 168 tests passing, clippy clean

## Test plan

- [x] All new tests pass on macOS (non-Windows stubs verified)
- [x] Windows-specific tests gated with `#[cfg(windows)]`
- [x] Performance assertions validated against test fixtures

Fixes #201, fixes #203, fixes #213, fixes #158
