### PR TITLE
fix: resolve Windows clippy errors in WMI detection

### DIFF
--- a/crates/astro-up-core/src/detect/hardware.rs
+++ b/crates/astro-up-core/src/detect/hardware.rs
@@ -65,7 +65,6 @@ pub async fn discover(
     manifest_patterns: &[(VidPid, String)],
     managed_packages: &std::collections::HashSet<String>,
 ) -> Vec<HardwareMatch> {
-    use serde::Deserialize as _;
     use std::time::Duration;
 
     #[derive(serde::Deserialize, Debug)]

--- a/crates/astro-up-core/src/detect/wmi_driver.rs
+++ b/crates/astro-up-core/src/detect/wmi_driver.rs
@@ -28,7 +28,7 @@ async fn detect_windows(config: &DetectionConfig) -> DetectionResult {
     use serde::Deserialize;
 
     #[derive(Deserialize, Debug)]
-    #[allow(non_snake_case)]
+    #[allow(non_snake_case, dead_code)]
     struct PnPSignedDriver {
         DriverProviderName: Option<String>,
         DeviceClass: Option<String>,


### PR DESCRIPTION
## Summary
- Remove unused `serde::Deserialize as _` import in `hardware.rs` (left over from WMI refactor in #259)
- Add `#[allow(dead_code)]` on `PnPSignedDriver` struct fields in `wmi_driver.rs` — fields are populated by WMI deserialization but not read directly by Rust code

## Context
PR #259 was squash-merged before these fixes landed. Windows CI (`cargo clippy -- -D warnings`) fails on main without them.

## Test plan
- [ ] Windows Integration CI passes (clippy clean)
