### PR TITLE
fix(013): quality gate findings, spec 003 reconciliation, pre-commit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,6 @@ dependencies = [
  "tracing",
  "trait-variant",
  "walkdir",
- "windows 0.62.2",
  "winreg 0.56.0",
  "wiremock",
  "wmi",
@@ -4026,16 +4025,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
-name = "signal-hook-registry"
-version = "1.4.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
-dependencies = [
- "errno",
- "libc",
-]
-
-[[package]]
 name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4724,7 +4713,6 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
- "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/crates/astro-up-core/src/backup/archive.rs
+++ b/crates/astro-up-core/src/backup/archive.rs
@@ -27,8 +27,10 @@ pub async fn create_backup(
     // Build archive filename: {package_id}_{version}_{YYYYMMDD_HHMMSS}.zip
     let timestamp = Utc::now();
     let ts_str = timestamp.format("%Y%m%d_%H%M%S").to_string();
-    let version_str = request.version.raw.replace('.', "-");
-    let filename = format!("{}_{}_{}.zip", request.package_id, version_str, ts_str);
+    let filename = format!(
+        "{}_{}_{}.zip",
+        request.package_id, request.version.raw, ts_str
+    );
     let archive_path = package_dir.join(&filename);
 
     let config_paths = request.config_paths.clone();
@@ -223,6 +225,25 @@ pub(crate) fn resolve_dir_names(paths: &[PathBuf]) -> Vec<String> {
         }
     }
     names
+}
+
+/// Reads metadata.json from a backup archive without extracting.
+pub async fn read_metadata(archive_path: &Path) -> Result<BackupMetadata, CoreError> {
+    let archive_path = archive_path.to_path_buf();
+    tokio::task::spawn_blocking(move || {
+        let file = File::open(&archive_path)?;
+        let mut archive =
+            zip::ZipArchive::new(file).map_err(|e| CoreError::Io(io::Error::other(e)))?;
+        let mut entry = archive
+            .by_name("metadata.json")
+            .map_err(|e| CoreError::Io(io::Error::other(e)))?;
+        let mut buf = String::new();
+        entry.read_to_string(&mut buf)?;
+        let metadata: BackupMetadata = serde_json::from_str(&buf)?;
+        Ok(metadata)
+    })
+    .await
+    .map_err(|e| CoreError::Io(io::Error::other(e)))?
 }
 
 /// Extracts a backup archive to the original paths stored in metadata.

--- a/crates/astro-up-core/src/backup/mod.rs
+++ b/crates/astro-up-core/src/backup/mod.rs
@@ -5,7 +5,7 @@ pub mod types;
 
 use std::path::{Path, PathBuf};
 
-use tracing::{info, instrument};
+use tracing::{info, instrument, warn};
 
 use crate::error::CoreError;
 use crate::events::Event;
@@ -61,6 +61,19 @@ impl BackupService {
 
     #[instrument(skip_all, fields(archive = %request.archive_path.display()))]
     pub async fn restore(&self, request: &RestoreRequest) -> Result<(), CoreError> {
+        // FR-009: Warn on version mismatch
+        if let Some(current_version) = &request.current_version {
+            if let Ok(metadata) = archive::read_metadata(&request.archive_path).await {
+                if metadata.version != *current_version {
+                    warn!(
+                        backup_version = %metadata.version.raw,
+                        current_version = %current_version.raw,
+                        "restoring backup from a different version"
+                    );
+                }
+            }
+        }
+
         let _ = request.event_tx.send(Event::RestoreStarted {
             id: request.archive_path.display().to_string(),
         });

--- a/crates/astro-up-core/src/backup/types.rs
+++ b/crates/astro-up-core/src/backup/types.rs
@@ -55,5 +55,6 @@ pub struct BackupRequest {
 pub struct RestoreRequest {
     pub archive_path: PathBuf,
     pub path_filter: Option<String>,
+    pub current_version: Option<Version>,
     pub event_tx: broadcast::Sender<Event>,
 }

--- a/specs/013-backup-restore/contracts/backup-service.rs
+++ b/specs/013-backup-restore/contracts/backup-service.rs
@@ -83,8 +83,9 @@ pub trait BackupManager: Send {
 /// Facade for backup operations. Implements BackupManager trait.
 pub struct BackupService {
     backup_dir: PathBuf, // {data_dir}/astro-up/backups/
+    retention: usize,    // auto-prune after backup (0 = unlimited)
 }
 
 impl BackupService {
-    pub fn new(backup_dir: PathBuf) -> Self;
+    pub fn new(backup_dir: PathBuf, retention: usize) -> Self;
 }

--- a/specs/013-backup-restore/spec.md
+++ b/specs/013-backup-restore/spec.md
@@ -129,7 +129,7 @@ A user runs `astro-up backup list nina` to see all backups. Old backups are auto
 ### Session 2026-03-31
 
 - Q: Should backup module implement its own path token expansion or reuse config system? → A: Reuse config module's `directories`-based path resolution (spec 004). DRY — tokens already handled there.
-- Q: Should BackupManager trait be kept minimal or evolved to match spec? → A: Evolve the trait to match spec requirements — add `restore_selective`, richer return types (`FileChangeSummary`), metadata-aware operations. Cross-spec change to spec 003 trait definition.
+- Q: Should BackupManager trait be kept minimal or evolved to match spec? → A: Evolve the trait to match spec requirements — add `restore_preview()`, richer return types (`FileChangeSummary`), metadata-aware operations. Cross-spec change to spec 003 trait definition.
 - Q: Should backup/restore emit events for progress tracking? → A: Add `BackupProgress { id, files_processed, total_files }`, `RestoreStarted { id }`, `RestoreComplete { id }` event variants. Covers GUI progress for large config directories.
 
 ## Success Criteria *(mandatory)*


### PR DESCRIPTION
## Summary

Post-merge quality gate fixes for spec 013 (backup-restore) + pre-commit config.

- Fix archive naming: remove dot-to-dash version transformation (FR-015 drift)
- Add version mismatch warning to restore (FR-009 was missing)
- Add `read_metadata()` public function and `current_version` to `RestoreRequest`
- Reconcile spec 003: FR-026 (BackupManager trait), FR-027 (new event variants)
- Update contract: add `retention` parameter to `BackupService::new`
- Add `.pre-commit-config.yaml` (trailing whitespace, end-of-file, yaml, toml, merge conflicts, large files, rust fmt, rust clippy)

## Test plan

- [x] 13 backup tests pass
- [x] Clippy clean
- [x] All pre-commit hooks pass
- [ ] CI passes
