### PR TITLE
fix(023): resolve clippy warnings from lifecycle testing merge

### DIFF
--- a/crates/astro-up-cli/tests/snapshots/cli_show__cli_help.snap
+++ b/crates/astro-up-cli/tests/snapshots/cli_show__cli_help.snap
@@ -11,16 +11,17 @@ Documentation: https://nightwatch-astro.github.io/astro-up/
 Usage: astro-up-cli [OPTIONS] <COMMAND>
 
 Commands:
-  show         Show software status
-  install      Install a package
-  update       Update installed packages
-  scan         Scan for installed software
-  search       Search the catalog
-  backup       Create a backup
-  restore      Restore from a backup
-  config       Manage configuration
-  self-update  Update astro-up itself
-  help         Print this message or the help of the given subcommand(s)
+  show            Show software status
+  install         Install a package
+  update          Update installed packages
+  scan            Scan for installed software
+  search          Search the catalog
+  backup          Create a backup
+  restore         Restore from a backup
+  config          Manage configuration
+  self-update     Update astro-up itself
+  lifecycle-test  Run lifecycle test for a package (download, install, detect, uninstall)
+  help            Print this message or the help of the given subcommand(s)
 
 Options:
       --json

--- a/crates/astro-up-core/src/detect/discovery.rs
+++ b/crates/astro-up-core/src/detect/discovery.rs
@@ -228,7 +228,7 @@ impl DiscoveryScanner {
                     DiscoveryConfidence::Medium
                 };
 
-                let registry_key =
+                let _registry_key =
                     format!(r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}");
 
                 candidates.push(DiscoveryCandidate {
@@ -591,7 +591,7 @@ impl DiscoveryScanner {
         let search_name = software.name.to_lowercase();
         let publisher = software.publisher.as_deref().unwrap_or("").to_lowercase();
 
-        let wmi_result: Result<Vec<std::collections::HashMap<String, wmi::Variant>>, _> =
+        let wmi_result: Result<Option<Vec<std::collections::HashMap<String, wmi::Variant>>>, _> =
             tokio::time::timeout(std::time::Duration::from_secs(10), async {
                 tokio::task::spawn_blocking(move || {
                     let com = wmi::COMLibrary::new().ok()?;

--- a/crates/astro-up-core/src/lifecycle.rs
+++ b/crates/astro-up-core/src/lifecycle.rs
@@ -8,7 +8,7 @@ use serde::Serialize;
 
 use crate::catalog::manifest::ManifestReader;
 use crate::detect::PathResolver;
-use crate::detect::discovery::{DiscoveryResult, DiscoveryScanner};
+use crate::detect::discovery::DiscoveryScanner;
 use crate::error::CoreError;
 use crate::types::{DetectionConfig, Software, Version};
 
@@ -95,7 +95,7 @@ impl LifecycleRunner {
         let mut discovered_config = None;
 
         // Phase 1: Download
-        let download_result = Self::run_download(&software, &version_str, &options).await;
+        let download_result = Self::run_download(&software, &version_str, options).await;
         let download_ok = matches!(download_result.status, PhaseStatus::Pass);
         let download_path = if download_ok {
             download_result.logs.first().cloned().map(PathBuf::from)
@@ -134,7 +134,7 @@ impl LifecycleRunner {
 
             // Phase 2: Install
             let install_result =
-                Self::run_install(&software, download_path.as_deref(), &options).await;
+                Self::run_install(&software, download_path.as_deref(), options).await;
             let install_ok = matches!(install_result.status, PhaseStatus::Pass);
             phases.push(install_result);
 
@@ -253,7 +253,7 @@ impl LifecycleRunner {
     async fn run_download(
         software: &Software,
         version: &str,
-        options: &LifecycleOptions,
+        _options: &LifecycleOptions,
     ) -> PhaseResult {
         let start = Instant::now();
 
@@ -294,14 +294,14 @@ impl LifecycleRunner {
         // This is a placeholder for the orchestration structure.
         #[cfg(not(windows))]
         {
-            return PhaseResult {
+            PhaseResult {
                 phase: "install".into(),
                 status: PhaseStatus::Skipped,
                 duration: start.elapsed(),
                 exit_code: None,
                 logs: vec![],
                 warnings: vec!["install requires Windows".into()],
-            };
+            }
         }
 
         #[cfg(windows)]
@@ -422,14 +422,14 @@ impl LifecycleRunner {
         #[cfg(not(windows))]
         {
             let _ = package_id;
-            return PhaseResult {
+            PhaseResult {
                 phase: "uninstall".into(),
                 status: PhaseStatus::Skipped,
                 duration: start.elapsed(),
                 exit_code: None,
                 logs: vec![],
                 warnings: vec!["uninstall requires Windows".into()],
-            };
+            }
         }
 
         #[cfg(windows)]


### PR DESCRIPTION
## Summary

- Remove unused import `DiscoveryResult` in lifecycle.rs
- Fix needless borrows in lifecycle runner calls
- Prefix unused variables with underscore
- Remove unneeded `return` statements
- Fix WMI result type annotation for Windows compilation
- Update CLI help snapshot for lifecycle-test command

Fixes clippy warnings introduced by the 023-lifecycle-testing squash merge.
