### PR TITLE
fix(023): skip firmware packages in lifecycle-test discovery

### DIFF
--- a/.github/workflows/lifecycle-test.yml
+++ b/.github/workflows/lifecycle-test.yml
@@ -61,7 +61,7 @@ jobs:
           else
             MISSING=$(cd manifests && \
               for f in manifests/*.toml; do
-                if grep -q '^\[install\]' "$f" && ! grep -q '^\[detection\]' "$f"; then
+                if grep -q '^\[install\]' "$f" && ! grep -q '^\[detection\]' "$f" && ! grep -q '^type = "resource"' "$f"; then
                   basename "$f" .toml
                 fi
               done | jq -R -s -c 'split("\n") | map(select(length > 0))')


### PR DESCRIPTION
## Summary

- Skip `type = "resource"` packages (firmware blobs) in lifecycle-test discovery sweep
- These 22 firmware packages are flashed to hardware via USB — no registry/PE detection possible
- Detection for firmware is handled by the ledger (tracks when Astro-Up downloads them)

## Test plan

- [ ] Re-run lifecycle-test workflow — should produce an empty matrix (no packages to test)
