### PR TITLE
fix: handle Ledger variant in detection match arms

### DIFF
--- a/crates/astro-up-core/src/catalog/reader.rs
+++ b/crates/astro-up-core/src/catalog/reader.rs
@@ -245,6 +245,7 @@ impl SqliteCatalogReader {
             "ascom_profile" => crate::types::DetectionMethod::AscomProfile,
             "file_exists" => crate::types::DetectionMethod::FileExists,
             "config_file" => crate::types::DetectionMethod::ConfigFile,
+            "ledger" => crate::types::DetectionMethod::Ledger,
             _ => {
                 tracing::warn!(package = %id, method = %method_str, "unknown detection method");
                 return Ok(None);

--- a/crates/astro-up-core/src/detect/mod.rs
+++ b/crates/astro-up-core/src/detect/mod.rs
@@ -128,6 +128,13 @@ async fn run_single_method(
         DetectionMethod::AscomProfile => ascom::detect(config).await,
         DetectionMethod::FileExists => file::detect_exists(config, resolver).await,
         DetectionMethod::ConfigFile => file::detect_config(config, resolver).await,
+        DetectionMethod::Ledger => DetectionResult {
+            detected: false,
+            version: None,
+            install_path: None,
+            duration: std::time::Duration::ZERO,
+            method: DetectionMethod::Ledger,
+        },
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `Ledger` match arm to `run_chain` in detect/mod.rs (returns not-detected — ledger packages are tracked by the store, not auto-detection)
- Add `"ledger"` string mapping in catalog reader

Fixes CI failure on release PR #733.
