### PR TITLE
chore(ci): add workflow_dispatch to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ name: Release
 on:
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Allow manual triggering of release workflow via `gh workflow run`.