### PR TITLE
fix: add version to workspace astro-up-core dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ garde = { version = "0.22", features = ["derive", "url"] }
 humantime = "2"
 humantime-serde = "1"
 tracing = "0.1"
-astro-up-core = { path = "crates/astro-up-core" }
+astro-up-core = { version = "0.1.0", path = "crates/astro-up-core" }
 insta = { version = "1", features = ["json", "toml"] }
 pretty_assertions = "1"
 rstest = "0.26"


### PR DESCRIPTION
## Summary

- Add `version = "0.1.0"` to workspace `astro-up-core` dependency
- `cargo publish` requires all deps to have a version (path is stripped for crates.io)
- astro-up-core published successfully, this unblocks astro-up-cli publishing
