### PR TITLE
docs: add README.md to core and cli crates for crates.io

### DIFF
--- a/crates/astro-up-cli/Cargo.toml
+++ b/crates/astro-up-cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "astro-up-cli"
 version = "0.1.0"
 description = "CLI for astro-up — astrophotography software manager"
 publish = true
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/astro-up-cli/README.md
+++ b/crates/astro-up-cli/README.md
@@ -1,0 +1,19 @@
+# astro-up-cli
+
+CLI for [Astro-Up](https://github.com/nightwatch-astro/astro-up) — manage astrophotography software on Windows from the command line.
+
+## Install
+
+```sh
+cargo install astro-up-cli
+```
+
+Or download a pre-built binary from [GitHub Releases](https://github.com/nightwatch-astro/astro-up/releases).
+
+## Documentation
+
+See the [Astro-Up documentation](https://nightwatch-astro.github.io/astro-up/) for usage and commands.
+
+## License
+
+Apache-2.0

--- a/crates/astro-up-core/Cargo.toml
+++ b/crates/astro-up-core/Cargo.toml
@@ -3,6 +3,7 @@ name = "astro-up-core"
 version = "0.1.0"
 description = "Shared library for astro-up — types, detection, download, install, engine"
 publish = true
+readme = "README.md"
 edition.workspace = true
 license.workspace = true
 repository.workspace = true

--- a/crates/astro-up-core/README.md
+++ b/crates/astro-up-core/README.md
@@ -1,0 +1,11 @@
+# astro-up-core
+
+Shared library for [Astro-Up](https://github.com/nightwatch-astro/astro-up) — types, detection, download, install, and orchestration engine for astrophotography software on Windows.
+
+## Documentation
+
+See the [Astro-Up documentation](https://nightwatch-astro.github.io/astro-up/) for usage and API reference.
+
+## License
+
+Apache-2.0


### PR DESCRIPTION
## Summary

- Add README.md to astro-up-core and astro-up-cli crates
- Add `readme = "README.md"` to both Cargo.toml files
- READMEs link to GitHub repo and docs site
- CLI README includes install instructions
