### PR TITLE
fix: skip GitHub release for core crate, fix download link

### DIFF
--- a/crates/astro-up-cli/README.md
+++ b/crates/astro-up-cli/README.md
@@ -8,7 +8,7 @@ CLI for [Astro-Up](https://github.com/nightwatch-astro/astro-up) — manage astr
 cargo install astro-up-cli
 ```
 
-Or download a pre-built binary from [GitHub Releases](https://github.com/nightwatch-astro/astro-up/releases).
+Or download a pre-built binary from the [latest release](https://github.com/nightwatch-astro/astro-up/releases/latest).
 
 ## Documentation
 

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -8,6 +8,11 @@ features_always_increment_minor = true
 dependencies_update = true
 pr_labels = ["release"]
 
+[[package]]
+name = "astro-up-core"
+git_release_enable = false
+git_tag_enable = false
+
 [changelog]
 commit_parsers = [
     { message = "^feat", group = "Features" },


### PR DESCRIPTION
## Summary

- Disable GitHub release + tag for `astro-up-core` (library, not user-facing) — still publishes to crates.io
- Only CLI and GUI get GitHub releases with binary artifacts
- Fix CLI README download link to point to `/releases/latest`
