### PR TITLE
fix: delete etag sidecars during purge, use config download_dir

### DIFF
--- a/crates/astro-up-cli/src/commands/install.rs
+++ b/crates/astro-up-cli/src/commands/install.rs
@@ -105,8 +105,13 @@ pub async fn handle_install(
     let db = state.open_db()?;
     let lock_path = state.data_dir.join("orchestration.lock");
 
+    let download_dir = if state.config.paths.download_dir.as_os_str().is_empty() {
+        std::env::temp_dir().join("astro-up").join("downloads")
+    } else {
+        state.config.paths.download_dir.clone()
+    };
     let orchestrator = UpdateOrchestrator::new(
-        &lock_path, packages, ledger, downloader, installer, backup, db,
+        &lock_path, packages, ledger, downloader, installer, backup, db, download_dir,
     )
     .map_err(|e| eyre!("failed to create orchestrator: {e}"))?;
 

--- a/crates/astro-up-cli/src/commands/update.rs
+++ b/crates/astro-up-cli/src/commands/update.rs
@@ -64,8 +64,13 @@ pub async fn handle_update(
     let db = state.open_db()?;
     let lock_path = state.data_dir.join("orchestration.lock");
 
+    let download_dir = if state.config.paths.download_dir.as_os_str().is_empty() {
+        std::env::temp_dir().join("astro-up").join("downloads")
+    } else {
+        state.config.paths.download_dir.clone()
+    };
     let orchestrator = UpdateOrchestrator::new(
-        &lock_path, packages, ledger, downloader, installer, backup, db,
+        &lock_path, packages, ledger, downloader, installer, backup, db, download_dir,
     )
     .map_err(|e| eyre!("failed to create orchestrator: {e}"))?;
 

--- a/crates/astro-up-core/src/download/purge.rs
+++ b/crates/astro-up-core/src/download/purge.rs
@@ -43,6 +43,17 @@ pub(crate) async fn purge(
                 if age > max_age {
                     let size = meta.len();
                     tokio::fs::remove_file(&path).await?;
+
+                    // Also remove companion .etag file so the downloader
+                    // won't send a stale If-None-Match on the next run.
+                    if let Some(name) = path.file_name() {
+                        let etag_path = path.with_file_name(format!(
+                            "{}.etag",
+                            name.to_string_lossy()
+                        ));
+                        let _ = tokio::fs::remove_file(&etag_path).await;
+                    }
+
                     files_deleted += 1;
                     bytes_reclaimed += size;
                 }

--- a/crates/astro-up-core/src/engine/orchestrator.rs
+++ b/crates/astro-up-core/src/engine/orchestrator.rs
@@ -161,6 +161,8 @@ where
     /// Shared database connection for history recording.
     #[allow(dead_code)]
     pub(crate) db: std::sync::Arc<std::sync::Mutex<rusqlite::Connection>>,
+    /// Directory for downloaded installers (from config `paths.download_dir`).
+    pub(crate) download_dir: PathBuf,
     /// Global orchestration lock — held for the lifetime of this struct.
     #[allow(dead_code)]
     pub(crate) lock: super::lock::OrchestrationLock,
@@ -201,6 +203,7 @@ where
         installer: I,
         backup: B,
         db: std::sync::Arc<std::sync::Mutex<rusqlite::Connection>>,
+        download_dir: PathBuf,
     ) -> Result<Self, CoreError> {
         let lock = super::lock::OrchestrationLock::acquire(lock_path)?;
 
@@ -211,6 +214,7 @@ where
             installer,
             backup,
             db,
+            download_dir,
             lock,
         })
     }
@@ -348,7 +352,7 @@ where
         let download_request = crate::download::DownloadRequest {
             url: planned.version_entry.url.clone(),
             expected_hash: planned.version_entry.sha256.clone(),
-            dest_dir: std::env::temp_dir().join("astro-up").join("downloads"),
+            dest_dir: self.download_dir.clone(),
             filename: Self::installer_filename(planned),
             resume: true,
         };
@@ -945,6 +949,7 @@ mod tests {
             MockInstaller,
             MockBackupManager,
             std::sync::Arc::new(std::sync::Mutex::new(db)),
+            std::env::temp_dir().join("astro-up").join("downloads"),
         )
     }
 
@@ -1028,6 +1033,7 @@ mod tests {
             SuccessInstaller,
             MockBackupManager,
             std::sync::Arc::new(std::sync::Mutex::new(db)),
+            std::env::temp_dir().join("astro-up").join("downloads"),
         )
     }
 
@@ -1053,6 +1059,7 @@ mod tests {
             CancellingInstaller,
             MockBackupManager,
             std::sync::Arc::new(std::sync::Mutex::new(db)),
+            std::env::temp_dir().join("astro-up").join("downloads"),
         )
     }
 

--- a/crates/astro-up-core/tests/engine_orchestrator.rs
+++ b/crates/astro-up-core/tests/engine_orchestrator.rs
@@ -194,6 +194,7 @@ fn build_success_orchestrator(
         SuccessInstaller,
         MockBackupManager,
         Arc::new(std::sync::Mutex::new(db)),
+        std::env::temp_dir().join("astro-up").join("downloads"),
     )
 }
 
@@ -218,6 +219,7 @@ fn build_failing_installer_with_backup_orchestrator(
         FailingInstaller,
         BackupWithPathManager,
         Arc::new(std::sync::Mutex::new(db)),
+        std::env::temp_dir().join("astro-up").join("downloads"),
     )
 }
 

--- a/crates/astro-up-gui/src/commands.rs
+++ b/crates/astro-up-gui/src/commands.rs
@@ -438,8 +438,13 @@ async fn run_orchestrated_operation(
                 rusqlite::Connection::open(&db_path).map_err(|e| CoreError::from(e.to_string()))?;
             let db = std::sync::Arc::new(std::sync::Mutex::new(db_conn));
 
+            let download_dir = if config.paths.download_dir.as_os_str().is_empty() {
+                std::env::temp_dir().join("astro-up").join("downloads")
+            } else {
+                config.paths.download_dir.clone()
+            };
             let orchestrator = astro_up_core::engine::orchestrator::UpdateOrchestrator::new(
-                &lock_path, packages, ledger, downloader, installer, backup, db,
+                &lock_path, packages, ledger, downloader, installer, backup, db, download_dir,
             )?;
 
             let plan = orchestrator


### PR DESCRIPTION
## Summary

- **purge.rs**: After deleting an installer file, also delete its `.etag` sidecar so the downloader won't send a stale `If-None-Match` header and falsely return `304 Cached`
- **orchestrator.rs**: Accept `download_dir` as a constructor parameter instead of hardcoding `std::env::temp_dir().join("astro-up").join("downloads")` — ensures the orchestrator downloads to the same directory the user configured and that `clear_directory` actually clears
- **CLI + GUI callers**: Resolve `download_dir` from `config.paths.download_dir` with a fallback to temp dir when unconfigured (empty `PathBuf`)

## Problem

When a user clears downloads via the Settings UI, `.etag` files survived because:
1. The purge function didn't clean up `.etag` companions when deleting installer files
2. The orchestrator hardcoded the download path to a temp directory, while `clear_directory` received the user-configured path — so the user was clearing a different directory than where downloads actually went

On the next install, the downloader found the `.etag` file, sent `If-None-Match` with the stored ETag, got `304 Not Modified`, and returned `Cached` even though the actual installer file was gone.

## Test plan

- [ ] Verify `cargo check` passes for `astro-up-core`, `astro-up-cli`
- [ ] Verify existing orchestrator tests still pass
- [ ] Manual: configure a custom `download_dir`, run an install, clear downloads, confirm `.etag` files are also removed
- [ ] Manual: run install again after clearing — should re-download instead of returning Cached
