### PR TITLE
fix(ci): remove redundant jobs + version-proof snapshot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,6 @@ jobs:
     name: Detect Changes
     runs-on: ubuntu-latest
     outputs:
-      gui: ${{ steps.filter.outputs.gui }}
       crates: ${{ steps.filter.outputs.crates }}
       frontend: ${{ steps.filter.outputs.frontend }}
     steps:
@@ -37,10 +36,6 @@ jobs:
         id: filter
         with:
           filters: |
-            gui:
-              - 'crates/astro-up-gui/**'
-              - 'Cargo.toml'
-              - 'Cargo.lock'
             crates:
               - 'crates/**'
               - 'Cargo.toml'
@@ -65,27 +60,6 @@ jobs:
       - run: cargo fmt --all -- --check
       - run: cargo clippy -p astro-up-core -p astro-up-cli -- -D warnings
       - run: cargo test -p astro-up-core -p astro-up-cli
-
-  check-gui:
-    name: Tauri GUI Check
-    needs: changes
-    if: needs.changes.outputs.gui == 'true'
-    runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
-    steps:
-      - uses: actions/checkout@v6
-      - name: Install Tauri system dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
-      - uses: dtolnay/rust-toolchain@stable
-        with:
-          components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
-      - run: cargo clippy -p astro-up-gui -- -D warnings
-      - run: cargo test -p astro-up-gui
 
   check-frontend:
     name: Frontend Checks
@@ -126,25 +100,24 @@ jobs:
         run: |
           choco install sqlite -y --no-progress
           sqlite3 crates/astro-up-cli/tests/fixtures/test-catalog.db < crates/astro-up-cli/tests/fixtures/build_catalog.sql
-      - run: cargo clippy --workspace -- -D warnings
-      - run: cargo test --workspace
+      - run: cargo clippy -p astro-up-gui -- -D warnings
+      - run: cargo test -p astro-up-core -p astro-up-gui
 
   # Gate job: always runs, reports single required status.
   # Branch protection should require only "CI OK" — skipped jobs pass through.
   ci-ok:
     name: CI OK
     if: always()
-    needs: [check-rust, check-frontend, check-gui, check-windows]
+    needs: [check-rust, check-frontend, check-windows]
     runs-on: ubuntu-latest
     steps:
       - name: Evaluate results
         env:
           RUST: ${{ needs.check-rust.result }}
           FRONTEND: ${{ needs.check-frontend.result }}
-          GUI: ${{ needs.check-gui.result }}
           WINDOWS: ${{ needs.check-windows.result }}
         run: |
-          for result in "$RUST" "$FRONTEND" "$GUI" "$WINDOWS"; do
+          for result in "$RUST" "$FRONTEND" "$WINDOWS"; do
             if [ "$result" = "failure" ]; then
               echo "Job failed: $result"
               exit 1

--- a/crates/astro-up-core/tests/config/defaults_test.rs
+++ b/crates/astro-up-core/tests/config/defaults_test.rs
@@ -50,7 +50,9 @@ fn load_config_with_empty_db_returns_defaults() {
             }
         }
     }
-    insta::assert_json_snapshot!("default_config", value);
+    insta::assert_json_snapshot!("default_config", value, {
+        ".network.user_agent" => "[user_agent]"
+    });
 }
 
 #[test]

--- a/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
+++ b/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
@@ -24,7 +24,7 @@ expression: value
     "download_speed_limit": 0,
     "proxy": null,
     "timeout": "30s",
-    "user_agent": "astro-up/0.1.1"
+    "user_agent": "[user_agent]"
   },
   "notifications": {
     "display_duration": 5,


### PR DESCRIPTION
## Summary

- Remove Tauri GUI Check job (redundant with Windows Integration)
- Windows Integration: clippy GUI only, test core+gui (core has cfg(windows) code)
- Redact user_agent version in config snapshot so it doesn't break on every release

## Test plan

- [ ] Rust Checks passes on Ubuntu
- [ ] Windows Integration passes with narrowed scope
- [ ] Config snapshot test passes without hardcoded version
