### PR TITLE
fix: match process exe path to handle Linux comm truncation

### DIFF
--- a/crates/astro-up-core/src/engine/process.rs
+++ b/crates/astro-up-core/src/engine/process.rs
@@ -41,10 +41,23 @@ fn refreshed_system() -> System {
 }
 
 /// Scan all processes for case-insensitive name matches.
+///
+/// Checks both `p.name()` (kernel comm field) and the exe path filename.
+/// On Linux the comm field is truncated to 15 characters, so long binary
+/// names only match via the exe path fallback.
 fn find_processes(sys: &System, name: &str) -> Vec<ProcessInfo> {
     sys.processes()
         .values()
-        .filter(|p| p.name().to_string_lossy().eq_ignore_ascii_case(name))
+        .filter(|p| {
+            if p.name().to_string_lossy().eq_ignore_ascii_case(name) {
+                return true;
+            }
+            // Fallback: match against the exe path filename (handles Linux
+            // 15-char comm truncation).
+            p.exe()
+                .and_then(|e| e.file_name())
+                .is_some_and(|f| f.to_string_lossy().eq_ignore_ascii_case(name))
+        })
         .map(|p| ProcessInfo {
             name: p.name().to_string_lossy().into_owned(),
             pid: p.pid().as_u32(),


### PR DESCRIPTION
## Summary
- Fix `find_processes` to also match against the exe path filename, not just `p.name()`
- On Linux the kernel `comm` field is truncated to 15 characters, so binaries with longer names (like nextest test runners) fail to match
- This fixes both the `process_blocking_emits_event_and_fails` CI test failure and a real-world bug where software with long exe names wouldn't trigger process blocking detection

## Test plan
- [ ] `process_blocking_emits_event_and_fails` passes on CI (Ubuntu + nextest)
- [ ] Existing process detection tests still pass
- [ ] Windows behavior unchanged (no comm truncation on Windows)
