### PR TITLE
chore: disable crates.io for core, OIDC for CLI, drop CI on main push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 concurrency:
   group: release-${{ github.ref }}
@@ -45,7 +46,6 @@ jobs:
   release:
     name: Create Release
     runs-on: ubuntu-latest
-    environment: crates-io
     outputs:
       releases_created: ${{ steps.release-plz.outputs.releases_created }}
       tag: ${{ steps.release-plz.outputs.tag }}
@@ -70,7 +70,6 @@ jobs:
           command: release
         env:
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   build-cli:
     name: Build CLI (${{ matrix.target }})

--- a/crates/astro-up-core/Cargo.toml
+++ b/crates/astro-up-core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "astro-up-core"
 version = "0.2.0"
 description = "Shared library for astro-up — types, detection, download, install, engine"
-publish = true
+publish = false
 readme = "README.md"
 edition.workspace = true
 license.workspace = true

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,5 +1,5 @@
 [workspace]
-publish = true
+publish = false
 git_tag_enable = true
 git_release_enable = true
 git_release_draft = false
@@ -12,6 +12,10 @@ pr_labels = ["release"]
 name = "astro-up-core"
 git_release_enable = false
 git_tag_enable = false
+
+[[package]]
+name = "astro-up-cli"
+publish = true
 
 [changelog]
 commit_parsers = [


### PR DESCRIPTION
## Summary
- `astro-up-core`: set `publish = false` in Cargo.toml and release-plz.toml (workspace-internal library, not needed on crates.io)
- `astro-up-cli`: switch from `CARGO_REGISTRY_TOKEN` to OIDC trusted publishing (`id-token: write`)
- Remove `crates-io` environment from release job (OIDC doesn't need it)
- Remove `push: branches: [main]` from CI (redundant — already runs on PR, branch protection gates merge)

Fixes the 403 from crates.io trusted publishing enforcement.

## Test plan
- [ ] CI passes on this PR
- [ ] After merge, dispatch release workflow — release-plz should skip core publish and use OIDC for CLI
- [ ] Yank `astro-up-core` 0.1.0 and 0.1.1 from crates.io manually
