### PR TITLE
fix: log astro-up version at startup for diagnostics

### DIFF
--- a/crates/astro-up-cli/src/main.rs
+++ b/crates/astro-up-cli/src/main.rs
@@ -38,6 +38,11 @@ async fn main() -> ExitCode {
         }
     };
 
+    tracing::info!(
+        version = astro_up_core::version(),
+        "starting astro-up"
+    );
+
     let cancel = CancellationToken::new();
     let cancel_clone = cancel.clone();
     tokio::spawn(async move {


### PR DESCRIPTION
## Summary
- Log version at startup via `tracing::info\!` for diagnostics
- Changes CLI crate source (not just core) to trigger release-plz version bump

## Test plan
- [ ] CI passes
- [ ] After merge, release-plz creates a release PR bumping CLI to 0.2.1
