### PR TITLE
fix: serialize CLI binary tests to avoid file lock contention

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,3 +1,13 @@
 [profile.default]
 # Retry flaky tests (network-dependent catalog download, Windows API timing)
 retries = 2
+
+# Tests that invoke the astro-up binary share a data directory and file lock.
+# Run them serially to avoid "another instance is running" lock contention.
+[[profile.default.overrides]]
+filter = "binary(cli_json) | binary(cli_integration)"
+threads-required = 1
+test-group = "serial-cli"
+
+[test-groups.serial-cli]
+max-threads = 1


### PR DESCRIPTION
## Summary
- Serialize CLI binary tests (`cli_json`, `cli_integration`) via nextest test groups
- These tests invoke `astro-up` binary which acquires a file lock on the shared data directory
- Parallel execution causes "another instance is running" errors

## Test plan
- [ ] `scan_json_is_valid` passes on Windows CI (no lock contention)
