### PR TITLE
fix(ci): remove publish=false that blocks release-plz version bumps

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -6,7 +6,6 @@ git_release_draft = true
 semver_check = false
 features_always_increment_minor = true
 dependencies_update = true
-publish = false
 pr_labels = ["release"]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Remove `publish = false` from release-plz workspace config
- `git_only = true` already prevents crates.io interaction
- `publish = false` was preventing release-plz from bumping versions in Cargo.toml

## Test plan
- [ ] After merge, release-plz creates a release PR with actual version bumps (0.1.0 → 0.2.0)
