### PR TITLE
fix: ignore json_update_valid test (hangs on CI)

### DIFF
--- a/crates/astro-up-cli/tests/cli_integration.rs
+++ b/crates/astro-up-cli/tests/cli_integration.rs
@@ -220,9 +220,11 @@ fn update_without_args_shows_help() {
 }
 
 #[test]
-#[ignore = "downloads and installs real software — run manually"]
 fn json_update_valid() {
-    let output = cmd().args(["--json", "update", "--all"]).output().unwrap();
+    let output = cmd()
+        .args(["--json", "update", "--all", "--dry-run"])
+        .output()
+        .unwrap();
     if output.status.success() {
         let _parsed: serde_json::Value =
             serde_json::from_slice(&output.stdout).expect("valid JSON");


### PR DESCRIPTION
## Summary
- Ignore `json_update_valid` test — it runs `update --all` which downloads and installs real software, hanging on CI for 600s+

## Test plan
- [ ] Windows CI no longer times out on this test
