### PR TITLE
fix(release): use GitHub App token so release-please PRs trigger CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,10 +21,17 @@ jobs:
       releases_created: ${{ steps.release.outputs.releases_created }}
       tag_name: ${{ steps.release.outputs['crates/astro-up-cli--tag_name'] }}
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          app-id: ${{ secrets.NIGHTWATCH_APP_ID }}
+          private-key: ${{ secrets.NIGHTWATCH_APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
   build:
     name: Build Windows (CLI + Installer)


### PR DESCRIPTION
## Summary

- Use Nightwatch GitHub App token instead of `GITHUB_TOKEN` in release-please action
- PRs created by `GITHUB_TOKEN` don't trigger workflows (GitHub's recursive workflow protection), so release-please PRs like #796 never get CI checks
- With the app token, release-please PRs will trigger CI normally, satisfying the "CI OK" branch protection requirement

## Test plan

- [ ] Merge this PR, then verify the next release-please run creates a PR that triggers CI
- [ ] Verify "CI OK" check appears on the release-please PR
