### PR TITLE
fix(release): keep release as draft until all builds succeed

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,7 +92,7 @@ jobs:
           tagName: ${{ needs.release-please.outputs.tag_name }}
           releaseName: ${{ needs.release-please.outputs.tag_name }}
           releaseBody: "See CHANGELOG.md for details."
-          releaseDraft: false
+          releaseDraft: true
           prerelease: false
           includeUpdaterJson: true
           updaterJsonPreferNsis: true


### PR DESCRIPTION
## Summary

- Set `releaseDraft: true` in tauri-action so it doesn't publish the release immediately after uploading artifacts
- The `publish-release` gate job already handles draft→published (on success) or delete draft+tag (on failure)
- Without this fix, tauri-action un-drafts the release before the gate can evaluate build results

## Release flow after this fix

1. **release-please** creates draft release + tag (`draft: true` in config)
2. **build** uploads CLI exe + Tauri installer to draft release (stays draft)
3. **publish-release** flips draft→published on success, deletes draft+tag on failure
