### PR TITLE
fix: correct beforeBuildCommand pnpm path for Tauri CWD

### DIFF
--- a/crates/astro-up-gui/tauri.conf.json
+++ b/crates/astro-up-gui/tauri.conf.json
@@ -4,8 +4,8 @@
   "identifier": "dev.nightwatch.astro-up",
   "version": "0.1.0",
   "build": {
-    "beforeDevCommand": "pnpm --dir ../../frontend dev",
-    "beforeBuildCommand": "pnpm --dir ../../frontend build",
+    "beforeDevCommand": "pnpm --dir ../frontend dev",
+    "beforeBuildCommand": "pnpm --dir ../frontend build",
     "devUrl": "http://localhost:5173",
     "frontendDist": "../../frontend/dist"
   },


### PR DESCRIPTION
## Summary

Fix `ENOENT` in release builds — Tauri runs `beforeBuildCommand` from `crates/` (parent of project dir), not from `crates/astro-up-gui/`. The path `../../frontend` resolved one level too high.

Verified locally: `cargo tauri build` from `crates/astro-up-gui/` now correctly finds and builds the frontend.

## Test plan

- [x] `cargo tauri build` succeeds locally from `crates/astro-up-gui/`
- [ ] Release build succeeds on CI after merging
