### PR TITLE
fix: use Cargo.toml version for Tauri app instead of hardcoded 0.1.0

### DIFF
--- a/crates/astro-up-gui/tauri.conf.json
+++ b/crates/astro-up-gui/tauri.conf.json
@@ -2,7 +2,6 @@
   "$schema": "https://raw.githubusercontent.com/tauri-apps/tauri/dev/crates/tauri-cli/schema.json",
   "productName": "Astro-Up",
   "identifier": "dev.nightwatch.astro-up",
-  "version": "0.1.0",
   "build": {
     "beforeDevCommand": "pnpm --dir ../frontend dev",
     "beforeBuildCommand": "pnpm --dir ../frontend build",


### PR DESCRIPTION
## Summary

The NSIS installer was built as `Astro-Up_0.1.0_x64-setup.nsis.zip` (hardcoded version in `tauri.conf.json`) while the release tag was `v0.1.7`. tauri-action couldn't find artifacts matching the release version → `No artifacts were found.`

Fix: remove `version` from `tauri.conf.json`. Tauri v2 falls back to `Cargo.toml` version, which release-please already manages. Single source of truth, no drift.

## Test plan

- [ ] Merge and verify release build produces installer with correct version in filename
- [ ] Verify tauri-action finds and uploads the artifacts to the draft release
