### PR TITLE
fix(release): use cargo tauri CLI and explicit CWD for build commands

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,6 +106,9 @@ jobs:
           cp target/x86_64-pc-windows-msvc/release/astro-up-cli.exe \
              crates/astro-up-gui/binaries/astro-up-cli-x86_64-pc-windows-msvc.exe
 
+      - name: Install Tauri CLI
+        run: cargo install tauri-cli --version ^2 --locked
+
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@84b9d35b5fc46c1e45415bdb6144030364f7ebc5 # v0
         env:
@@ -114,6 +117,7 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
         with:
           projectPath: crates/astro-up-gui
+          tauriScript: cargo tauri
           tagName: ${{ needs.release-please.outputs.tag_name }}
           releaseName: ${{ needs.release-please.outputs.tag_name }}
           releaseBody: ${{ needs.release-please.outputs.release_notes }}

--- a/crates/astro-up-gui/tauri.conf.json
+++ b/crates/astro-up-gui/tauri.conf.json
@@ -3,8 +3,14 @@
   "productName": "Astro-Up",
   "identifier": "dev.nightwatch.astro-up",
   "build": {
-    "beforeDevCommand": "pnpm --dir ../frontend dev",
-    "beforeBuildCommand": "pnpm --dir ../frontend build",
+    "beforeDevCommand": {
+      "script": "pnpm dev",
+      "cwd": "../../frontend"
+    },
+    "beforeBuildCommand": {
+      "script": "pnpm build",
+      "cwd": "../../frontend"
+    },
     "devUrl": "http://localhost:5173",
     "frontendDist": "../../frontend/dist"
   },


### PR DESCRIPTION
## Summary

Fix the release build: NSIS bundler never ran because the globally installed `@tauri-apps/cli` (via `npm install -g`) had version mismatch issues with the workspace's `tauri` crate.

### Changes

1. **`cargo tauri` instead of global npm install** — `cargo install tauri-cli` is version-locked to the workspace, avoiding CLI/crate version mismatches that cause silent bundling failures
2. **Object form for `beforeBuildCommand`** — explicit `cwd: "../../frontend"` resolved relative to `tauri.conf.json` location, instead of relying on undocumented `frontend_dir()` fallback behavior
3. **Tested locally** — `cargo tauri build` from `crates/astro-up-gui/` produces the frontend build + Rust compilation successfully

### Root cause

tauri-action without `tauriScript` globally installs `@tauri-apps/cli@v2` via npm. This version may not match the `tauri` crate version in the workspace, causing the bundler to silently skip NSIS/MSI generation. The binary compiles but no installer is produced.

## Test plan

- [x] `cargo tauri build` succeeds locally from `crates/astro-up-gui/`
- [ ] Release build on CI produces NSIS installer + uploads to draft release
