### PR TITLE
fix: enable bundle targets in tauri.conf.json

### DIFF
--- a/crates/astro-up-gui/tauri.conf.json
+++ b/crates/astro-up-gui/tauri.conf.json
@@ -31,6 +31,8 @@
     }
   },
   "bundle": {
+    "active": true,
+    "targets": ["nsis"],
     "externalBin": [
       "binaries/astro-up-cli"
     ]


### PR DESCRIPTION
## Summary

The Tauri bundler was silently skipping NSIS/MSI generation because `bundle.active` and `bundle.targets` weren't set in `tauri.conf.json`. The binary compiled but no installer was produced.

Fix: add `"active": true, "targets": "all"` to the bundle config.

Verified locally: `cargo tauri build` now runs the bundler (`.app` + `.dmg` on macOS, will produce NSIS + MSI on Windows).

## Test plan

- [x] `cargo tauri build` produces bundles locally
- [ ] Release build on CI produces NSIS installer + uploads to draft release
