### PR TITLE
fix(gui): allow data: URIs in CSP for base64 package icons

### DIFF
--- a/crates/astro-up-gui/tauri.conf.json
+++ b/crates/astro-up-gui/tauri.conf.json
@@ -27,7 +27,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; img-src 'self' data:; script-src 'self'; style-src 'self' 'unsafe-inline'"
     }
   },
   "bundle": {


### PR DESCRIPTION
## Summary
- Add `img-src 'self' data:` to Tauri CSP to allow base64-encoded package icons
- WebKit in Tauri enforces CSP strictly (unlike browsers), blocking `data:` URIs unless explicitly permitted
- Icons rendered via `PackageIcon.vue` as `data:image/png;base64,...` were invisible in the production build

## Test plan
- [ ] Build Tauri app and verify package icons display in catalog/detail views
- [ ] Verify no CSP console errors in WebKit devtools
