### PR TITLE
fix(release): sync core version and add project name to release title

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,5 @@
 {
-  "crates/astro-up-core": "0.1.0",
+  "crates/astro-up-core": "0.1.10",
   "crates/astro-up-cli": "0.1.10",
   "crates/astro-up-gui": "0.1.10"
 }

--- a/crates/astro-up-core/Cargo.toml
+++ b/crates/astro-up-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-core"
-version = "0.1.0"
+version = "0.1.10"
 description = "Shared library for astro-up — types, detection, download, install, engine"
 publish = false
 readme = "README.md"

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,7 @@
   "bump-patch-for-minor-pre-major": true,
   "draft": true,
   "include-component-in-tag": false,
-  "group-pull-request-title-pattern": "chore: release ${version}",
+  "group-pull-request-title-pattern": "chore: release astro-up ${version}",
   "linked-versions": true,
   "packages": {
     "crates/astro-up-core": {


### PR DESCRIPTION
## Summary
- Sync `astro-up-core` version from `0.1.0` to `0.1.10` to match cli/gui — fixes linked-versions producing two changelog entries per release
- Add "astro-up" to release PR title pattern: `chore: release astro-up v0.1.11`

## Test plan
- [ ] Next release-please run produces a single version entry in the PR body
