### PR TITLE
fix(release): single root package to eliminate duplicate changelog sections

### DIFF
--- a/.release-please-manifest.json
+++ b/.release-please-manifest.json
@@ -1,5 +1,3 @@
 {
-  "crates/astro-up-core": "0.1.10",
-  "crates/astro-up-cli": "0.1.10",
-  "crates/astro-up-gui": "0.1.10"
+  ".": "0.1.10"
 }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -6,21 +6,16 @@
   "draft": true,
   "include-component-in-tag": false,
   "group-pull-request-title-pattern": "chore: release astro-up ${version}",
-  "linked-versions": true,
   "packages": {
-    "crates/astro-up-core": {
-      "component": "astro-up-core"
-    },
-    "crates/astro-up-cli": {
-      "component": "astro-up-cli"
-    },
-    "crates/astro-up-gui": {
-      "component": "astro-up-gui"
+    ".": {
+      "component": "astro-up",
+      "changelog-path": "CHANGELOG.md"
     }
   },
   "plugins": [
     {
-      "type": "cargo-workspace"
+      "type": "cargo-workspace",
+      "merge": true
     }
   ],
   "changelog-sections": [


### PR DESCRIPTION
## Summary
- Switch from 3 per-crate packages to single root package with `cargo-workspace` plugin (`merge: true`)
- Eliminates duplicate changelog sections in release PR body (was 3x identical `0.1.11` entries)
- Single changelog at `CHANGELOG.md`, single version, single release

## Test plan
- [ ] Close #859, merge this, trigger release workflow — verify single changelog section in new PR
