### PR TITLE
fix(release): use workspace version for single changelog

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ resolver = "2"
 members = ["crates/astro-up-core", "crates/astro-up-cli", "crates/astro-up-gui"]
 
 [workspace.package]
+version = "0.1.10"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/nightwatch-astro/astro-up"
@@ -81,7 +82,7 @@ garde = { version = "0.22", features = ["derive", "url"] }
 humantime = "2"
 humantime-serde = "1"
 tracing = "0.1"
-astro-up-core = { version = "0.1.0", path = "crates/astro-up-core" }
+astro-up-core = { version = "0.1.10", path = "crates/astro-up-core" }
 insta = { version = "1", features = ["json", "toml", "redactions"] }
 pretty_assertions = "1"
 rstest = "0.26"

--- a/crates/astro-up-cli/Cargo.toml
+++ b/crates/astro-up-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-cli"
-version = "0.1.10"
+version.workspace = true
 description = "CLI for astro-up — astrophotography software manager"
 publish = false
 readme = "README.md"

--- a/crates/astro-up-core/Cargo.toml
+++ b/crates/astro-up-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-core"
-version = "0.1.10"
+version.workspace = true
 description = "Shared library for astro-up — types, detection, download, install, engine"
 publish = false
 readme = "README.md"

--- a/crates/astro-up-gui/Cargo.toml
+++ b/crates/astro-up-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-gui"
-version = "0.1.10"
+version.workspace = true
 description = "Tauri v2 desktop app for astro-up — astrophotography software manager"
 publish = false
 edition.workspace = true


### PR DESCRIPTION
## Summary
- Move `version = "0.1.10"` to `[workspace.package]` in root Cargo.toml
- All 3 crates inherit via `version.workspace = true`
- release-please config uses single root `.` package with `cargo-workspace` plugin (`merge: true`)
- Produces one changelog section per release instead of three duplicates

## Test plan
- [x] `cargo check` passes with workspace version inheritance
- [ ] Merge, close stale release PR, trigger release workflow — verify single changelog
