### PR TITLE
fix(release): explicit crate versions for cargo-workspace compatibility

### DIFF
--- a/crates/astro-up-cli/Cargo.toml
+++ b/crates/astro-up-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-cli"
-version.workspace = true
+version = "0.1.10"
 description = "CLI for astro-up — astrophotography software manager"
 publish = false
 readme = "README.md"

--- a/crates/astro-up-core/Cargo.toml
+++ b/crates/astro-up-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-core"
-version.workspace = true
+version = "0.1.10"
 description = "Shared library for astro-up — types, detection, download, install, engine"
 publish = false
 readme = "README.md"

--- a/crates/astro-up-gui/Cargo.toml
+++ b/crates/astro-up-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-gui"
-version.workspace = true
+version = "0.1.10"
 description = "Tauri v2 desktop app for astro-up — astrophotography software manager"
 publish = false
 edition.workspace = true


### PR DESCRIPTION
## Summary
- Revert `version.workspace = true` to explicit `version = "0.1.10"` in all 3 crates
- Keep `version = "0.1.10"` in `[workspace.package]` for release-please root package tracking
- `cargo-workspace` plugin bumps all explicit versions together on release

Fixes: `release-please failed: cargo-workspace: package manifest has an invalid [package.version]`

## Test plan
- [ ] Merge, trigger release workflow — verify no cargo-workspace parse error
- [ ] Verify single changelog section in release PR
