### PR TITLE
fix(lifecycle): resolve versions from catalog, fix exit codes

### DIFF
--- a/.github/workflows/lifecycle-test.yml
+++ b/.github/workflows/lifecycle-test.yml
@@ -116,8 +116,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p astro-up/target/release
-          if gh release download --repo nightwatch-astro/astro-up --pattern 'astro-up-cli-x86_64-pc-windows-msvc.exe' --dir astro-up/target/release --clobber 2>/dev/null; then
-            mv astro-up/target/release/astro-up-cli-x86_64-pc-windows-msvc.exe astro-up/target/release/astro-up-cli.exe
+          if gh release download --repo nightwatch-astro/astro-up --pattern 'astro-up-cli.exe' --dir astro-up/target/release --clobber 2>/dev/null; then
             echo "source=release" >> "$GITHUB_OUTPUT"
           else
             echo "source=build" >> "$GITHUB_OUTPUT"
@@ -138,17 +137,33 @@ jobs:
           rustup default stable
           cargo build --release -p astro-up-cli
 
+      - name: Download catalog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release download catalog/latest \
+            --repo nightwatch-astro/astro-up-manifests \
+            --pattern 'catalog.db' \
+            --dir astro-up/ \
+            --clobber
+
       - name: Run lifecycle test
         id: lifecycle
         working-directory: astro-up
         shell: pwsh
+        env:
+          CATALOG_DB: ${{ github.workspace }}/astro-up/catalog.db
+          MANIFESTS_DIR: ${{ github.workspace }}/manifests
+          REPORT_FILE: ${{ github.workspace }}/report.json
         run: |
           $args = @(
             "lifecycle-test",
             $env:PACKAGE_ID,
-            "--manifest-path", "${{ github.workspace }}/manifests",
+            "--manifest-path", $env:MANIFESTS_DIR,
+            "--catalog-path", $env:CATALOG_DB,
             "--json",
-            "--report-file", "${{ github.workspace }}/report.json"
+            "--report-file", $env:REPORT_FILE
           )
           if ($env:INPUT_VERSION -ne "") {
             $args += "--version"
@@ -158,9 +173,9 @@ jobs:
             $args += "--dry-run"
           }
           & ./target/release/astro-up-cli.exe @args
-          echo "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
-          # Don't fail the step — exit codes handled in PR step
-          exit 0
+          $exitCode = $LASTEXITCODE
+          echo "exit_code=$exitCode" >> $env:GITHUB_OUTPUT
+          exit $exitCode
 
       - name: Upload report
         if: always()

--- a/crates/astro-up-cli/src/commands/lifecycle_test.rs
+++ b/crates/astro-up-cli/src/commands/lifecycle_test.rs
@@ -15,6 +15,7 @@ pub async fn handle_lifecycle_test(
     manifest_path: &Path,
     version: Option<&str>,
     install_dir: Option<&Path>,
+    catalog_path: Option<&Path>,
     dry_run: bool,
     report_file: Option<&Path>,
     mode: &OutputMode,
@@ -52,6 +53,7 @@ pub async fn handle_lifecycle_test(
         package_id: package_id.to_string(),
         version: version.map(String::from),
         install_dir: install_dir.map(std::borrow::ToOwned::to_owned),
+        catalog_path: catalog_path.map(std::borrow::ToOwned::to_owned),
         dry_run,
         ..Default::default()
     };

--- a/crates/astro-up-cli/src/lib.rs
+++ b/crates/astro-up-cli/src/lib.rs
@@ -117,6 +117,9 @@ pub enum Commands {
         /// Install directory for `download_only` packages
         #[arg(long)]
         install_dir: Option<PathBuf>,
+        /// Path to compiled catalog.db for version resolution
+        #[arg(long)]
+        catalog_path: Option<PathBuf>,
         /// Download and probe only, skip install/uninstall
         #[arg(long)]
         dry_run: bool,
@@ -217,6 +220,7 @@ pub async fn run(cli: Cli, cancel: CancellationToken) -> Result<()> {
             ref manifest_path,
             ref version,
             ref install_dir,
+            ref catalog_path,
             dry_run,
             ref report_file,
         } => {
@@ -225,6 +229,7 @@ pub async fn run(cli: Cli, cancel: CancellationToken) -> Result<()> {
                 manifest_path,
                 version.as_deref(),
                 install_dir.as_deref(),
+                catalog_path.as_deref(),
                 dry_run,
                 report_file.as_deref(),
                 &mode,

--- a/crates/astro-up-core/src/lifecycle.rs
+++ b/crates/astro-up-core/src/lifecycle.rs
@@ -82,6 +82,10 @@ pub struct LifecycleOptions {
     pub install_dir: Option<PathBuf>,
     pub dry_run: bool,
     pub timeout: Duration,
+    /// Path to a compiled catalog.db — used to resolve the latest version
+    /// when `version` is `None`. Falls back to the `versions/` directory scan
+    /// if not provided.
+    pub catalog_path: Option<PathBuf>,
 }
 
 impl Default for LifecycleOptions {
@@ -93,6 +97,7 @@ impl Default for LifecycleOptions {
             install_dir: None,
             dry_run: false,
             timeout: Duration::from_secs(600), // 10 minutes
+            catalog_path: None,
         }
     }
 }
@@ -114,8 +119,27 @@ impl LifecycleRunner {
 
         let version_str = match &options.version {
             Some(v) => v.clone(),
-            None => Self::resolve_latest_version(&options.manifest_path, &options.package_id)?
-                .to_string(),
+            None => {
+                if let Some(catalog_path) = &options.catalog_path {
+                    // Resolve from compiled catalog
+                    let reader = crate::catalog::reader::SqliteCatalogReader::open(catalog_path)?;
+                    let pkg_id =
+                        crate::catalog::PackageId::new(&options.package_id).map_err(|e| {
+                            CoreError::NotFound {
+                                input: e.to_string(),
+                            }
+                        })?;
+                    reader
+                        .latest_version(&pkg_id)?
+                        .ok_or_else(|| CoreError::NotFound {
+                            input: format!("no versions in catalog for '{}'", options.package_id),
+                        })?
+                        .version
+                } else {
+                    Self::resolve_latest_version(&options.manifest_path, &options.package_id)?
+                        .to_string()
+                }
+            }
         };
 
         let mut phases = Vec::new();

--- a/crates/astro-up-core/tests/lifecycle_dry_run.rs
+++ b/crates/astro-up-core/tests/lifecycle_dry_run.rs
@@ -46,6 +46,7 @@ async fn dry_run_skips_install_uninstall() {
         package_id: "test-pkg".into(),
         version: Some("1.0.0".into()),
         install_dir: None,
+        catalog_path: None,
         dry_run: true,
         timeout: Duration::from_secs(30),
     };
@@ -91,6 +92,7 @@ async fn dry_run_resolves_download_url() {
         package_id: "test-pkg".into(),
         version: Some("2.5.0".into()),
         install_dir: None,
+        catalog_path: None,
         dry_run: true,
         timeout: Duration::from_secs(30),
     };
@@ -119,6 +121,7 @@ async fn dry_run_overall_not_fail_on_no_detection() {
         package_id: "test-pkg".into(),
         version: Some("1.0.0".into()),
         install_dir: None,
+        catalog_path: None,
         dry_run: true,
         timeout: Duration::from_secs(30),
     };


### PR DESCRIPTION
## Summary

- Resolve latest version from compiled `catalog.db` instead of scanning empty `versions/` directory
- Add `--catalog-path` CLI flag to lifecycle-test command
- Download `catalog.db` from `catalog/latest` release in CI workflow
- Fix exit code propagation (was swallowed by `exit 0`)

The `versions/` directory in git is empty — version data lives in `pipeline-state.tar.gz` on the release. Instead of downloading and extracting that, we now query the compiled catalog directly using the existing `SqliteCatalogReader::latest_version()` method.

Falls back to `versions/` directory scan if `--catalog-path` is not provided.

## Test plan

- [x] `cargo check -p astro-up-core -p astro-up-cli` passes
- [x] All existing lifecycle tests pass (catalog_path: None uses fallback)
- [ ] Run lifecycle test for nina-app after merge
