### PR TITLE
fix(lifecycle): auto-discover catalog.db, fix exit codes

### DIFF
--- a/.github/workflows/lifecycle-test.yml
+++ b/.github/workflows/lifecycle-test.yml
@@ -116,8 +116,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p astro-up/target/release
-          if gh release download --repo nightwatch-astro/astro-up --pattern 'astro-up-cli-x86_64-pc-windows-msvc.exe' --dir astro-up/target/release --clobber 2>/dev/null; then
-            mv astro-up/target/release/astro-up-cli-x86_64-pc-windows-msvc.exe astro-up/target/release/astro-up-cli.exe
+          if gh release download --repo nightwatch-astro/astro-up --pattern 'astro-up-cli.exe' --dir astro-up/target/release --clobber 2>/dev/null; then
             echo "source=release" >> "$GITHUB_OUTPUT"
           else
             echo "source=build" >> "$GITHUB_OUTPUT"
@@ -138,17 +137,31 @@ jobs:
           rustup default stable
           cargo build --release -p astro-up-cli
 
+      - name: Download catalog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          gh release download catalog/latest \
+            --repo nightwatch-astro/astro-up-manifests \
+            --pattern 'catalog.db' \
+            --dir manifests/ \
+            --clobber
+
       - name: Run lifecycle test
         id: lifecycle
         working-directory: astro-up
         shell: pwsh
+        env:
+          MANIFESTS_DIR: ${{ github.workspace }}/manifests
+          REPORT_FILE: ${{ github.workspace }}/report.json
         run: |
           $args = @(
             "lifecycle-test",
             $env:PACKAGE_ID,
-            "--manifest-path", "${{ github.workspace }}/manifests",
+            "--manifest-path", $env:MANIFESTS_DIR,
             "--json",
-            "--report-file", "${{ github.workspace }}/report.json"
+            "--report-file", $env:REPORT_FILE
           )
           if ($env:INPUT_VERSION -ne "") {
             $args += "--version"
@@ -158,9 +171,9 @@ jobs:
             $args += "--dry-run"
           }
           & ./target/release/astro-up-cli.exe @args
-          echo "exit_code=$LASTEXITCODE" >> $env:GITHUB_OUTPUT
-          # Don't fail the step — exit codes handled in PR step
-          exit 0
+          $exitCode = $LASTEXITCODE
+          echo "exit_code=$exitCode" >> $env:GITHUB_OUTPUT
+          exit $exitCode
 
       - name: Upload report
         if: always()

--- a/crates/astro-up-cli/src/commands/lifecycle_test.rs
+++ b/crates/astro-up-cli/src/commands/lifecycle_test.rs
@@ -15,6 +15,7 @@ pub async fn handle_lifecycle_test(
     manifest_path: &Path,
     version: Option<&str>,
     install_dir: Option<&Path>,
+    catalog_path: Option<&Path>,
     dry_run: bool,
     report_file: Option<&Path>,
     mode: &OutputMode,
@@ -52,6 +53,7 @@ pub async fn handle_lifecycle_test(
         package_id: package_id.to_string(),
         version: version.map(String::from),
         install_dir: install_dir.map(std::borrow::ToOwned::to_owned),
+        catalog_path: catalog_path.map(std::borrow::ToOwned::to_owned),
         dry_run,
         ..Default::default()
     };

--- a/crates/astro-up-cli/src/lib.rs
+++ b/crates/astro-up-cli/src/lib.rs
@@ -117,6 +117,9 @@ pub enum Commands {
         /// Install directory for `download_only` packages
         #[arg(long)]
         install_dir: Option<PathBuf>,
+        /// Path to compiled catalog.db for version resolution
+        #[arg(long)]
+        catalog_path: Option<PathBuf>,
         /// Download and probe only, skip install/uninstall
         #[arg(long)]
         dry_run: bool,
@@ -217,6 +220,7 @@ pub async fn run(cli: Cli, cancel: CancellationToken) -> Result<()> {
             ref manifest_path,
             ref version,
             ref install_dir,
+            ref catalog_path,
             dry_run,
             ref report_file,
         } => {
@@ -225,6 +229,7 @@ pub async fn run(cli: Cli, cancel: CancellationToken) -> Result<()> {
                 manifest_path,
                 version.as_deref(),
                 install_dir.as_deref(),
+                catalog_path.as_deref(),
                 dry_run,
                 report_file.as_deref(),
                 &mode,

--- a/crates/astro-up-core/src/lifecycle.rs
+++ b/crates/astro-up-core/src/lifecycle.rs
@@ -114,8 +114,30 @@ impl LifecycleRunner {
 
         let version_str = match &options.version {
             Some(v) => v.clone(),
-            None => Self::resolve_latest_version(&options.manifest_path, &options.package_id)?
-                .to_string(),
+            None => {
+                let catalog_candidate = options.manifest_path.join("catalog.db");
+                if catalog_candidate.exists() {
+                    // Auto-discover catalog.db alongside manifests
+                    let reader =
+                        crate::catalog::reader::SqliteCatalogReader::open(&catalog_candidate)?;
+                    let pkg_id =
+                        crate::catalog::PackageId::new(&options.package_id).map_err(|e| {
+                            CoreError::NotFound {
+                                input: e.to_string(),
+                            }
+                        })?;
+                    info!("resolving version from catalog.db");
+                    reader
+                        .latest_version(&pkg_id)?
+                        .ok_or_else(|| CoreError::NotFound {
+                            input: format!("no versions in catalog for '{}'", options.package_id),
+                        })?
+                        .version
+                } else {
+                    Self::resolve_latest_version(&options.manifest_path, &options.package_id)?
+                        .to_string()
+                }
+            }
         };
 
         let mut phases = Vec::new();

--- a/crates/astro-up-core/tests/lifecycle_dry_run.rs
+++ b/crates/astro-up-core/tests/lifecycle_dry_run.rs
@@ -46,6 +46,7 @@ async fn dry_run_skips_install_uninstall() {
         package_id: "test-pkg".into(),
         version: Some("1.0.0".into()),
         install_dir: None,
+        catalog_path: None,
         dry_run: true,
         timeout: Duration::from_secs(30),
     };
@@ -91,6 +92,7 @@ async fn dry_run_resolves_download_url() {
         package_id: "test-pkg".into(),
         version: Some("2.5.0".into()),
         install_dir: None,
+        catalog_path: None,
         dry_run: true,
         timeout: Duration::from_secs(30),
     };
@@ -119,6 +121,7 @@ async fn dry_run_overall_not_fail_on_no_detection() {
         package_id: "test-pkg".into(),
         version: Some("1.0.0".into()),
         install_dir: None,
+        catalog_path: None,
         dry_run: true,
         timeout: Duration::from_secs(30),
     };


### PR DESCRIPTION
## Summary

- Auto-discover `catalog.db` alongside manifest path instead of requiring `--catalog-path` flag
- Download `catalog.db` into manifests checkout dir so runner finds it automatically
- Remove `--catalog-path` from workflow args (works with old and new CLI binaries)
- Fix exit code propagation (was `exit 0`, now propagates actual exit code)

## Test plan

- [x] `cargo fmt --check` passes
- [x] Existing lifecycle tests pass (fallback to versions/ when no catalog.db)
- [ ] Run lifecycle test for nina-app after merge
