### PR TITLE
fix(release): remove custom title pattern blocking release tagging

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -5,7 +5,6 @@
   "bump-patch-for-minor-pre-major": true,
   "draft": true,
   "include-component-in-tag": false,
-  "group-pull-request-title-pattern": "chore: release astro-up ${version}",
   "packages": {
     ".": {
       "component": "astro-up",


### PR DESCRIPTION
## Summary

Remove custom `group-pull-request-title-pattern` from release-please config.

The custom pattern `chore: release astro-up ${version}` doesn't match what cargo-workspace merge actually generates (`chore: release main`). This causes release-please to log `Bad pull request title` and skip tag/release creation for merged release PRs.

Without a custom pattern, release-please uses its default which matches correctly.

## Test plan

- [ ] Merge this, then re-run Release workflow — release-please should tag the pending v0.1.11 release
