### PR TITLE
fix(release): use workspace version inheritance, remove cargo-workspace plugin

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up"
-version = "0.1.12"
+version.workspace = true
 publish = false
 edition.workspace = true
 license.workspace = true
@@ -11,7 +11,7 @@ resolver = "2"
 members = ["crates/astro-up-core", "crates/astro-up-cli", "crates/astro-up-gui"]
 
 [workspace.package]
-version = "0.1.10"
+version = "0.1.12"
 edition = "2024"
 license = "Apache-2.0"
 repository = "https://github.com/nightwatch-astro/astro-up"

--- a/crates/astro-up-cli/Cargo.toml
+++ b/crates/astro-up-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-cli"
-version = "0.1.12"
+version.workspace = true
 description = "CLI for astro-up — astrophotography software manager"
 publish = false
 readme = "README.md"

--- a/crates/astro-up-core/Cargo.toml
+++ b/crates/astro-up-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-core"
-version = "0.1.12"
+version.workspace = true
 description = "Shared library for astro-up — types, detection, download, install, engine"
 publish = false
 readme = "README.md"

--- a/crates/astro-up-gui/Cargo.toml
+++ b/crates/astro-up-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-gui"
-version = "0.1.12"
+version.workspace = true
 description = "Tauri v2 desktop app for astro-up — astrophotography software manager"
 publish = false
 edition.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,12 +11,7 @@
       "changelog-path": "CHANGELOG.md"
     }
   },
-  "plugins": [
-    {
-      "type": "cargo-workspace",
-      "merge": true
-    }
-  ],
+  "plugins": [],
   "exclude-paths": [
     "specs",
     ".specify",


### PR DESCRIPTION
## Summary

- All crates now use `version.workspace = true` instead of hardcoded versions
- Single version source of truth: `[workspace.package].version` in root Cargo.toml
- Remove `cargo-workspace` plugin from release-please — no longer needed
- Fixes release-please tagging failure (`Bad pull request title` / `untagged PRs outstanding`)

The cargo-workspace plugin was forcing PR titles to `chore: release main` (no version), which release-please couldn't parse back for tagging. With workspace inheritance, release-please only bumps the root version and all crates inherit.

## Test plan

- [x] `cargo check -p astro-up-core -p astro-up-cli` — all crates resolve to 0.1.12
- [ ] After merge, release-please should create a properly titled release PR
