### PR TITLE
fix(release): set group title pattern to chore: release version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.12"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,13 @@
       "changelog-path": "CHANGELOG.md"
     }
   },
-  "plugins": [],
+  "group-pull-request-title-pattern": "chore: release ${version}",
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": true
+    }
+  ],
   "exclude-paths": [
     "specs",
     ".specify",


### PR DESCRIPTION
## Summary

Set `group-pull-request-title-pattern` to `chore: release ${version}` so release-please can parse the version from merged PRs and create tags.

The previous pattern `chore: release astro-up ${version}` didn't match what cargo-workspace merge generates. Removing the pattern entirely resulted in `undefined`. This pattern works with the cargo-workspace plugin.

## Test plan

- [ ] After merge, trigger Release workflow — release-please should create a tagged release
