### PR TITLE
fix(release): restore cargo-workspace plugin, fix title pattern, revert version.workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.12"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.10"
+version = "0.1.12"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up"
-version.workspace = true
+version = "0.1.12"
 publish = false
 edition.workspace = true
 license.workspace = true

--- a/crates/astro-up-cli/Cargo.toml
+++ b/crates/astro-up-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-cli"
-version.workspace = true
+version = "0.1.12"
 description = "CLI for astro-up — astrophotography software manager"
 publish = false
 readme = "README.md"

--- a/crates/astro-up-core/Cargo.toml
+++ b/crates/astro-up-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-core"
-version.workspace = true
+version = "0.1.12"
 description = "Shared library for astro-up — types, detection, download, install, engine"
 publish = false
 readme = "README.md"

--- a/crates/astro-up-gui/Cargo.toml
+++ b/crates/astro-up-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "astro-up-gui"
-version.workspace = true
+version = "0.1.12"
 description = "Tauri v2 desktop app for astro-up — astrophotography software manager"
 publish = false
 edition.workspace = true

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,7 +11,13 @@
       "changelog-path": "CHANGELOG.md"
     }
   },
-  "plugins": [],
+  "group-pull-request-title-pattern": "chore: release ${version}",
+  "plugins": [
+    {
+      "type": "cargo-workspace",
+      "merge": true
+    }
+  ],
   "exclude-paths": [
     "specs",
     ".specify",


### PR DESCRIPTION
## Summary

Set `group-pull-request-title-pattern` to `chore: release ${version}` so release-please can parse the version from merged PRs and create tags.

The previous pattern `chore: release astro-up ${version}` didn't match what cargo-workspace merge generates. Removing the pattern entirely resulted in `undefined`. This pattern works with the cargo-workspace plugin.

## Test plan

- [ ] After merge, trigger Release workflow — release-please should create a tagged release
