### PR TITLE
fix(release): remove merge:true from cargo-workspace plugin

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -11,11 +11,9 @@
       "changelog-path": "CHANGELOG.md"
     }
   },
-  "group-pull-request-title-pattern": "chore: release ${version}",
   "plugins": [
     {
-      "type": "cargo-workspace",
-      "merge": true
+      "type": "cargo-workspace"
     }
   ],
   "exclude-paths": [


### PR DESCRIPTION
## Summary

Remove `merge: true` from the cargo-workspace plugin. With one package, merge is unnecessary and it forces PR titles to `chore: release main` (no version), which release-please can't parse back for tagging.

Without merge, the PR title will be `chore(main): release astro-up v0.1.14` — release-please can parse the version and create the tag.

The cargo-workspace plugin still syncs versions across all crate Cargo.tomls.

## Test plan

- [ ] After merge, trigger Release workflow — release-please should create a PR with version in title
