### PR TITLE
feat(cli): add catalog sync/refresh commands

### DIFF
--- a/crates/astro-up-cli/src/commands/catalog.rs
+++ b/crates/astro-up-cli/src/commands/catalog.rs
@@ -1,0 +1,41 @@
+use color_eyre::eyre::{Result, eyre};
+
+use crate::CatalogAction;
+use crate::output::OutputMode;
+use crate::output::json::print_json;
+use crate::state::CliState;
+
+pub async fn handle_catalog(
+    state: &CliState,
+    action: CatalogAction,
+    mode: &OutputMode,
+) -> Result<()> {
+    tracing::debug!(?action, "entering handle_catalog");
+
+    let result = match action {
+        CatalogAction::Sync => state.catalog_manager.ensure_catalog().await,
+        CatalogAction::Refresh => state.catalog_manager.refresh().await,
+    };
+
+    let fetch_result = result.map_err(|e| eyre!("catalog operation failed: {e}"))?;
+
+    if *mode == OutputMode::Json {
+        return print_json(&serde_json::json!({
+            "result": format!("{fetch_result:?}"),
+            "path": state.catalog_path().display().to_string(),
+        }));
+    }
+
+    if mode.should_print() {
+        let reader = state.open_catalog_reader()?;
+        let count = reader.list_all()?.len();
+        match action {
+            CatalogAction::Sync => println!("Catalog synced ({fetch_result:?}). {count} packages."),
+            CatalogAction::Refresh => {
+                println!("Catalog refreshed ({fetch_result:?}). {count} packages.");
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/crates/astro-up-cli/src/commands/mod.rs
+++ b/crates/astro-up-cli/src/commands/mod.rs
@@ -1,4 +1,5 @@
 pub mod backup;
+pub mod catalog;
 pub mod config;
 pub mod install;
 pub mod lifecycle_test;

--- a/crates/astro-up-cli/src/lib.rs
+++ b/crates/astro-up-cli/src/lib.rs
@@ -92,6 +92,12 @@ pub enum Commands {
         yes: bool,
     },
 
+    /// Manage the package catalog
+    Catalog {
+        #[command(subcommand)]
+        action: CatalogAction,
+    },
+
     /// Manage configuration
     Config {
         #[command(subcommand)]
@@ -139,6 +145,14 @@ pub enum ShowFilter {
     Outdated,
     /// Show backups
     Backups { package: Option<String> },
+}
+
+#[derive(Debug, Subcommand)]
+pub enum CatalogAction {
+    /// Sync catalog (download if stale or missing)
+    Sync,
+    /// Force re-download the catalog regardless of TTL
+    Refresh,
 }
 
 #[derive(Subcommand)]
@@ -203,6 +217,9 @@ pub async fn run(cli: Cli, cancel: CancellationToken) -> Result<()> {
             )
             .await
         }
+        Commands::Catalog { action } => {
+            commands::catalog::handle_catalog(&state, action, &mode).await
+        }
         Commands::Scan => commands::scan::handle_scan(&state, &mode).await,
         Commands::Search { ref query } => {
             commands::search::handle_search(&state, query, &mode).await
@@ -236,7 +253,7 @@ pub async fn run(cli: Cli, cancel: CancellationToken) -> Result<()> {
             )
             .await
         }
-        // Already handled above
+        // Already handled above (Config + SelfUpdate run without shared state)
         Commands::Config { .. } | Commands::SelfUpdate { .. } => unreachable!(),
     };
     tracing::debug!(ok = result.is_ok(), "command dispatch complete");

--- a/crates/astro-up-cli/src/main.rs
+++ b/crates/astro-up-cli/src/main.rs
@@ -63,6 +63,7 @@ async fn main() -> ExitCode {
         astro_up_cli::Commands::Search { .. } => "search",
         astro_up_cli::Commands::Backup { .. } => "backup",
         astro_up_cli::Commands::Restore { .. } => "restore",
+        astro_up_cli::Commands::Catalog { .. } => "catalog",
         astro_up_cli::Commands::Config { .. } => "config",
         astro_up_cli::Commands::SelfUpdate { .. } => "self-update",
         astro_up_cli::Commands::LifecycleTest { .. } => "lifecycle-test",

--- a/crates/astro-up-cli/tests/snapshots/cli_show__cli_help.snap
+++ b/crates/astro-up-cli/tests/snapshots/cli_show__cli_help.snap
@@ -18,6 +18,7 @@ Commands:
   search          Search the catalog
   backup          Create a backup
   restore         Restore from a backup
+  catalog         Manage the package catalog
   config          Manage configuration
   self-update     Update astro-up-cli itself
   lifecycle-test  Run lifecycle test for a package (download, install, detect, uninstall)


### PR DESCRIPTION
## Summary

Adds CLI commands for managing the package catalog:
- `astro-up catalog sync` — download if stale or missing (respects TTL)
- `astro-up catalog refresh` — force re-download regardless of TTL

## Test plan

- [ ] `astro-up catalog sync` downloads catalog on first run, shows "Unchanged" on repeat
- [ ] `astro-up catalog refresh` always re-downloads
- [ ] `astro-up catalog sync --json` returns JSON with result and path
