### PR TITLE
fix: add json feature to tracing-subscriber for GUI file logging

### DIFF
--- a/crates/astro-up-gui/Cargo.toml
+++ b/crates/astro-up-gui/Cargo.toml
@@ -35,7 +35,7 @@ tokio = { version = "1", features = ["sync", "time", "macros", "rt"] }
 tokio-util = { version = "0.7", features = ["rt"] }
 tracing.workspace = true
 tracing-appender = "0.2.4"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3", features = ["env-filter", "json"] }
 uuid = { version = "1", features = ["v4"] }
 
 [dev-dependencies]


### PR DESCRIPTION
Missing feature flag caused build failure on Windows. The json feature is needed for the daily-rotated JSON log file writer added in the log rotation PR.
