### PR TITLE
fix: only show Backup button for packages with backup config

### DIFF
--- a/frontend/src/components/detail/DetailHero.vue
+++ b/frontend/src/components/detail/DetailHero.vue
@@ -72,7 +72,7 @@ defineEmits<{
         @click="$emit('install')"
       />
       <Button
-        v-if="pkg.installed_version"
+        v-if="pkg.backup?.config_paths?.length"
         label="Backup Now"
         icon="pi pi-database"
         severity="secondary"

--- a/frontend/src/components/installed/PackageRow.vue
+++ b/frontend/src/components/installed/PackageRow.vue
@@ -48,7 +48,7 @@ defineEmits<{
       @click.stop
     >
       <Button
-        v-if="pkg.installed_version"
+        v-if="pkg.backup?.config_paths?.length"
         icon="pi pi-database"
         label="Backup Now"
         text


### PR DESCRIPTION
Only show Backup Now button in installed list and detail hero when the package has backup config_paths defined in the catalog.
