### PR TITLE
fix: search filter matches package ID in Installed view

### DIFF
--- a/frontend/src/views/InstalledView.vue
+++ b/frontend/src/views/InstalledView.vue
@@ -34,7 +34,10 @@ const filtered = computed(() => {
   const q = searchFilter.value.trim().toLowerCase();
   if (!q) return installed.value;
   return installed.value.filter(
-    (p) => p.name.toLowerCase().includes(q) || p.category.toLowerCase().includes(q),
+    (p) =>
+      p.id.toLowerCase().includes(q) ||
+      p.name.toLowerCase().includes(q) ||
+      p.category.toLowerCase().includes(q),
   );
 });
 


### PR DESCRIPTION
## Summary

- The Installed Software view's search filter now matches against `p.id` in addition to `p.name` and `p.category`
- This fixes searching for packages by short name/ID (e.g., searching "nina" now finds "N.I.N.A")
- CatalogView already searches by ID via the `useSearch` composable, so no change needed there

## Test plan

- [ ] Search "nina" in the Installed view -- should match the N.I.N.A package
- [ ] Search "N.I.N.A" still matches by name as before
- [ ] Search by category still works
- [ ] Empty search still shows all installed packages
