### PR TITLE
feat: frontend update queue with per-package progress and button disabling

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -73,7 +73,7 @@ describe("View smoke tests", () => {
     expect(wrapper.text()).toContain("Dashboard");
     expect(wrapper.text()).toContain("Installed");
     expect(wrapper.text()).toContain("Updates");
-    expect(wrapper.text()).toContain("Recent Activity");
+    expect(wrapper.text()).toContain("Scan Installed");
   });
 
   it("Catalog renders search and grid", async () => {

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -13,6 +13,7 @@ import AppStatusBar from "./components/layout/AppStatusBar.vue";
 import OperationsDock from "./components/layout/OperationsDock.vue";
 import LogPanel from "./components/layout/LogPanel.vue";
 import AssetSelectionDialog from "./components/shared/AssetSelectionDialog.vue";
+import { useUpdateQueue } from "./composables/useUpdateQueue";
 import type { CoreEvent } from "./types/commands";
 
 const toast = useToast();
@@ -46,6 +47,7 @@ onErrorCaptured((err, instance, info) => {
   return false; // prevent propagation
 });
 const { updateProgress, completeOperation, failOperation, addStep, startOperation, isRunning } = useOperations();
+const { isActive: queueActive, markCurrentComplete, markCurrentFailed, markCurrentBlocked, currentItem } = useUpdateQueue();
 const logVisible = ref(false);
 const logPanel = ref<InstanceType<typeof LogPanel> | null>(null);
 
@@ -110,19 +112,35 @@ useCoreEvents((event: CoreEvent) => {
     const pct = Math.round((event.data.files_processed / event.data.total_files) * 100);
     updateProgress(pct, `Backing up: ${event.data.files_processed}/${event.data.total_files}`);
   } else if (event.type === "package_started") {
-    startOperation(event.data.package_id, `Installing ${event.data.package_id}`);
+    if (queueActive.value) {
+      const item = currentItem.value;
+      const label = item ? `Updating ${item.packageName}` : `Updating ${event.data.package_id}`;
+      startOperation(event.data.package_id, label);
+    } else {
+      startOperation(event.data.package_id, `Installing ${event.data.package_id}`);
+    }
   } else if (event.type === "download_started") {
     if (!isRunning.value) startOperation(event.data.id, `Downloading ${event.data.id}`);
     addStep("info", "Download started");
   } else if (event.type === "download_complete") {
     addStep("info", "Download complete");
   } else if (event.type === "process_blocking") {
-    toast.add({
-      severity: "error",
-      summary: "Application is running",
-      detail: `Please close ${event.data.process_name} (PID ${event.data.pid}) before installing or updating ${event.data.package_id}.`,
-      life: 10000,
-    });
+    if (queueActive.value) {
+      markCurrentBlocked(event.data.process_name, event.data.pid);
+      toast.add({
+        severity: "warn",
+        summary: `Skipped ${event.data.package_id}`,
+        detail: `${event.data.process_name} is running (PID ${event.data.pid})`,
+        life: 5000,
+      });
+    } else {
+      toast.add({
+        severity: "error",
+        summary: "Application is running",
+        detail: `Please close ${event.data.process_name} (PID ${event.data.pid}) before installing or updating ${event.data.package_id}.`,
+        life: 10000,
+      });
+    }
   } else if (event.type === "scan_started") {
     startOperation("scan", "Scanning installed software");
   } else if (event.type === "scan_complete") {
@@ -134,14 +152,15 @@ useCoreEvents((event: CoreEvent) => {
   } else if (event.type === "package_complete") {
     if (event.data.status === "failed") {
       const reason = event.data.error ?? "unknown error";
+      if (queueActive.value) markCurrentFailed(reason);
       failOperation(`${event.data.package_id}: ${reason}`);
     } else {
+      if (queueActive.value) markCurrentComplete();
       completeOperation();
     }
   } else if (event.type === "orchestration_complete") {
-    addStep("info", `Done: ${event.data.succeeded} succeeded, ${event.data.failed} failed`);
-    if (!isRunning.value) {
-      // Single-package orchestration already handled by package_complete
+    if (!queueActive.value) {
+      addStep("info", `Done: ${event.data.succeeded} succeeded, ${event.data.failed} failed`);
     }
   }
 

--- a/frontend/src/components/detail/BackupTab.vue
+++ b/frontend/src/components/detail/BackupTab.vue
@@ -10,6 +10,7 @@ import type { BackupListEntry } from "../../types/backup";
 const props = defineProps<{
   packageId: string;
   configPaths?: string[];
+  actionsDisabled?: boolean;
 }>();
 
 defineEmits<{
@@ -145,6 +146,7 @@ function formatDate(iso: string): string {
           label="Backup Now"
           icon="pi pi-database"
           size="small"
+          :disabled="actionsDisabled"
           @click="$emit('backup')"
         />
       </div>

--- a/frontend/src/components/detail/DetailHero.vue
+++ b/frontend/src/components/detail/DetailHero.vue
@@ -6,6 +6,7 @@ import type { PackageWithStatus } from "../../types/package";
 
 defineProps<{
   pkg: PackageWithStatus;
+  actionsDisabled?: boolean;
 }>();
 
 defineEmits<{
@@ -55,6 +56,7 @@ defineEmits<{
         label="Update"
         icon="pi pi-arrow-up"
         severity="warn"
+        :disabled="actionsDisabled"
         @click="$emit('update')"
       />
       <Button
@@ -69,6 +71,7 @@ defineEmits<{
         v-else
         label="Install"
         icon="pi pi-download"
+        :disabled="actionsDisabled"
         @click="$emit('install')"
       />
       <Button
@@ -77,6 +80,7 @@ defineEmits<{
         icon="pi pi-database"
         severity="secondary"
         outlined
+        :disabled="actionsDisabled"
         @click="$emit('backup')"
       />
       <Button

--- a/frontend/src/components/detail/VersionsTab.vue
+++ b/frontend/src/components/detail/VersionsTab.vue
@@ -8,6 +8,7 @@ import type { VersionEntry } from "../../types/package";
 defineProps<{
   versions: VersionEntry[];
   installedVersion: string | null;
+  actionsDisabled?: boolean;
 }>();
 
 defineEmits<{
@@ -70,6 +71,7 @@ function formatDate(iso: string): string {
           label="Install"
           size="small"
           outlined
+          :disabled="actionsDisabled"
           @click="$emit('install', (data as VersionEntry).version)"
         />
       </template>

--- a/frontend/src/components/installed/PackageRow.vue
+++ b/frontend/src/components/installed/PackageRow.vue
@@ -5,6 +5,7 @@ import type { PackageWithStatus } from "../../types/package";
 
 defineProps<{
   pkg: PackageWithStatus;
+  actionsDisabled?: boolean;
 }>();
 
 defineEmits<{
@@ -55,6 +56,7 @@ defineEmits<{
         size="small"
         severity="secondary"
         class="action-btn"
+        :disabled="actionsDisabled"
         @click="$emit('backup')"
       />
       <Button
@@ -63,6 +65,7 @@ defineEmits<{
         severity="warn"
         size="small"
         class="action-btn"
+        :disabled="actionsDisabled"
         @click="$emit('update')"
       />
     </div>

--- a/frontend/src/components/layout/OperationsDock.vue
+++ b/frontend/src/components/layout/OperationsDock.vue
@@ -3,23 +3,33 @@ import { ref, watch } from "vue";
 import ProgressBar from "primevue/progressbar";
 import Button from "primevue/button";
 import { useOperations } from "../../composables/useOperations";
+import { useUpdateQueue } from "../../composables/useUpdateQueue";
 import { useCancelOperation } from "../../composables/useInvoke";
 
 const { operation, dismissOperation, cancelOperation } = useOperations();
+const { isActive: queueActive, progress: queueProgress, queueLabel, summary: queueSummary, items: queueItems, cancelQueue, clearQueue } = useUpdateQueue();
 const cancelMutation = useCancelOperation();
 
 const expanded = ref(false);
 let autoDismissTimer: ReturnType<typeof setTimeout> | null = null;
 
 function handleCancel() {
-  if (operation.value) {
+  if (queueActive.value) {
+    cancelQueue();
+  } else if (operation.value) {
     cancelMutation.mutate(operation.value.id, {
       onSuccess: () => cancelOperation(),
     });
   }
 }
 
-// Auto-dismiss 3s after complete
+function handleDismiss() {
+  if (queueItems.value.length > 0) clearQueue();
+  dismissOperation();
+  expanded.value = false;
+}
+
+// Auto-dismiss 3s after complete (suppress during queue — queue manages lifecycle)
 watch(
   () => operation.value?.status,
   (status) => {
@@ -28,7 +38,7 @@ watch(
       autoDismissTimer = null;
     }
 
-    if (status === "complete") {
+    if (status === "complete" && !queueActive.value) {
       autoDismissTimer = setTimeout(() => {
         dismissOperation();
         expanded.value = false;
@@ -40,11 +50,40 @@ watch(
 
 <template>
   <div
-    v-if="operation"
+    v-if="operation || (!queueActive && queueItems.length > 0)"
     class="ops-dock"
     :class="{ expanded }"
   >
+    <!-- Queue progress header -->
     <div
+      v-if="queueActive"
+      class="ops-queue-bar"
+    >
+      <i class="pi pi-list" />
+      <span>{{ queueLabel }}</span>
+      <span class="ops-queue-counter">{{ queueProgress.current }}/{{ queueProgress.total }}</span>
+    </div>
+
+    <!-- Queue summary (shown after queue completes) -->
+    <div
+      v-else-if="queueItems.length > 0"
+      class="ops-queue-bar ops-queue-summary"
+    >
+      <i class="pi pi-check-circle" />
+      <span>{{ queueSummary.succeeded }} succeeded, {{ queueSummary.failed }} failed</span>
+      <Button
+        icon="pi pi-times"
+        text
+        rounded
+        size="small"
+        severity="secondary"
+        title="Dismiss"
+        @click.stop="handleDismiss"
+      />
+    </div>
+
+    <div
+      v-if="operation"
       class="ops-header"
       @click="expanded = !expanded"
     >
@@ -95,39 +134,41 @@ watch(
           @click.stop="expanded = !expanded"
         />
         <Button
-          v-if="operation.status !== 'running'"
+          v-if="operation.status !== 'running' && !queueActive"
           icon="pi pi-times"
           text
           rounded
           size="small"
           severity="secondary"
           title="Dismiss"
-          @click.stop="dismissOperation()"
+          @click.stop="handleDismiss"
         />
       </div>
     </div>
 
-    <ProgressBar
-      v-if="operation.status === 'running'"
-      :value="operation.progress"
-      :show-value="false"
-      class="ops-progress"
-    />
+    <template v-if="operation">
+      <ProgressBar
+        v-if="operation.status === 'running'"
+        :value="operation.progress"
+        :show-value="false"
+        class="ops-progress"
+      />
 
-    <div
-      v-if="expanded && operation.steps.length > 0"
-      class="ops-steps"
-    >
       <div
-        v-for="(step, i) in operation.steps"
-        :key="i"
-        class="ops-step"
-        :class="step.level"
+        v-if="expanded && operation.steps.length > 0"
+        class="ops-steps"
       >
-        <span class="step-time">{{ step.timestamp.slice(11, 19) }}</span>
-        <span class="step-message">{{ step.message }}</span>
+        <div
+          v-for="(step, i) in operation.steps"
+          :key="i"
+          class="ops-step"
+          :class="step.level"
+        >
+          <span class="step-time">{{ step.timestamp.slice(11, 19) }}</span>
+          <span class="step-message">{{ step.message }}</span>
+        </div>
       </div>
-    </div>
+    </template>
   </div>
 </template>
 
@@ -214,5 +255,26 @@ watch(
 .step-time {
   color: var(--p-surface-500);
   flex-shrink: 0;
+}
+
+.ops-queue-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  font-size: 12px;
+  color: var(--p-primary-400);
+  background: color-mix(in srgb, var(--p-primary-500) 8%, transparent);
+  border-bottom: 1px solid var(--p-surface-700);
+}
+
+.ops-queue-counter {
+  margin-left: auto;
+  font-weight: 600;
+}
+
+.ops-queue-summary {
+  color: var(--p-surface-300);
+  background: transparent;
 }
 </style>

--- a/frontend/src/composables/useInvoke.ts
+++ b/frontend/src/composables/useInvoke.ts
@@ -189,6 +189,7 @@ export function useLastScan() {
   return useQuery({
     queryKey: ["last-scan"],
     queryFn: () => invoke<{ last_scan_at: string | null }>("get_last_scan"),
+    retry: false,
   });
 }
 

--- a/frontend/src/composables/useUpdateQueue.ts
+++ b/frontend/src/composables/useUpdateQueue.ts
@@ -1,0 +1,169 @@
+import { ref, computed, readonly } from "vue";
+import { invoke } from "@tauri-apps/api/core";
+import { useQueryClient } from "@tanstack/vue-query";
+import { logger } from "../utils/logger";
+import type { OperationId } from "../types/commands";
+
+export type QueueItemStatus = "pending" | "running" | "complete" | "failed" | "cancelled";
+
+export interface QueueItem {
+  packageId: string;
+  packageName: string;
+  status: QueueItemStatus;
+  error?: string;
+}
+
+// Singleton state (same pattern as useOperations.ts)
+const queue = ref<QueueItem[]>([]);
+const currentIndex = ref(-1);
+const _isActive = ref(false);
+const isCancelling = ref(false);
+const currentOperationId = ref<string | null>(null);
+
+export function useUpdateQueue() {
+  const isActive = computed(() => _isActive.value);
+
+  const currentItem = computed(() =>
+    currentIndex.value >= 0 ? queue.value[currentIndex.value] ?? null : null,
+  );
+
+  const progress = computed(() => ({
+    current: currentIndex.value + 1,
+    total: queue.value.length,
+  }));
+
+  const queueLabel = computed(() => {
+    const item = currentItem.value;
+    if (!item) return "";
+    return `Updating ${progress.value.current}/${progress.value.total}: ${item.packageName}`;
+  });
+
+  const summary = computed(() => {
+    const counts = { succeeded: 0, failed: 0, cancelled: 0 };
+    for (const item of queue.value) {
+      if (item.status === "complete") counts.succeeded++;
+      else if (item.status === "failed") counts.failed++;
+      else if (item.status === "cancelled") counts.cancelled++;
+    }
+    return counts;
+  });
+
+  async function enqueue(packages: Array<{ id: string; name: string }>) {
+    if (_isActive.value || packages.length === 0) return;
+
+    queue.value = packages.map((p) => ({
+      packageId: p.id,
+      packageName: p.name,
+      status: "pending" as const,
+    }));
+    currentIndex.value = 0;
+    _isActive.value = true;
+    isCancelling.value = false;
+
+    logger.debug("useUpdateQueue", `enqueued ${packages.length} packages`);
+
+    for (let i = 0; i < queue.value.length; i++) {
+      if (isCancelling.value) {
+        for (let j = i; j < queue.value.length; j++) {
+          queue.value[j].status = "cancelled";
+        }
+        break;
+      }
+
+      currentIndex.value = i;
+      queue.value[i].status = "running";
+
+      try {
+        const result = await invoke<OperationId>("update_software", {
+          id: queue.value[i].packageId,
+        });
+        currentOperationId.value = result.id;
+        // By the time invoke resolves, package_complete event has already
+        // updated the status via markCurrentComplete/Failed. Safety net:
+        if (queue.value[i].status === "running") {
+          queue.value[i].status = "complete";
+        }
+      } catch (err) {
+        queue.value[i].status = "failed";
+        queue.value[i].error =
+          err instanceof Error ? err.message : String(err);
+      }
+
+      currentOperationId.value = null;
+    }
+
+    _isActive.value = false;
+    currentIndex.value = -1;
+
+    logger.debug(
+      "useUpdateQueue",
+      `queue complete: ${summary.value.succeeded} ok, ${summary.value.failed} failed`,
+    );
+
+    // Invalidate queries once at the end
+    const queryClient = useQueryClient();
+    queryClient.invalidateQueries({ queryKey: ["software"] });
+    queryClient.invalidateQueries({ queryKey: ["updates"] });
+    queryClient.invalidateQueries({ queryKey: ["activity"] });
+  }
+
+  async function cancelQueue() {
+    isCancelling.value = true;
+    if (currentOperationId.value) {
+      try {
+        await invoke("cancel_operation", {
+          operationId: currentOperationId.value,
+        });
+      } catch {
+        // ignore — operation may have already finished
+      }
+    }
+  }
+
+  function clearQueue() {
+    queue.value = [];
+    currentIndex.value = -1;
+    _isActive.value = false;
+    isCancelling.value = false;
+    currentOperationId.value = null;
+  }
+
+  function markCurrentComplete() {
+    if (!_isActive.value || currentIndex.value < 0) return;
+    const item = queue.value[currentIndex.value];
+    if (item?.status === "running") item.status = "complete";
+  }
+
+  function markCurrentFailed(error: string) {
+    if (!_isActive.value || currentIndex.value < 0) return;
+    const item = queue.value[currentIndex.value];
+    if (item) {
+      item.status = "failed";
+      item.error = error;
+    }
+  }
+
+  function markCurrentBlocked(processName: string, pid: number) {
+    if (!_isActive.value || currentIndex.value < 0) return;
+    const item = queue.value[currentIndex.value];
+    if (item) {
+      item.status = "failed";
+      item.error = `${processName} is running (PID ${pid})`;
+    }
+  }
+
+  return {
+    isActive,
+    currentItem,
+    progress,
+    queueLabel,
+    items: readonly(queue),
+    summary,
+    enqueue,
+    cancelQueue,
+    clearQueue,
+    markCurrentComplete,
+    markCurrentFailed,
+    markCurrentBlocked,
+  };
+}

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -4,7 +4,7 @@ import { useRouter } from "vue-router";
 import Button from "primevue/button";
 import ConfirmDialog from "../components/shared/ConfirmDialog.vue";
 import PackageIcon from "../components/shared/PackageIcon.vue";
-import { useSoftwareList, useScanInstalled, useUpdateSoftware } from "../composables/useInvoke";
+import { useSoftwareList, useScanInstalled, useUpdateSoftware, useLastScan } from "../composables/useInvoke";
 import { useOperations } from "../composables/useOperations";
 import { useUpdateQueue } from "../composables/useUpdateQueue";
 import { logger } from "../utils/logger";
@@ -17,6 +17,7 @@ const scanMutation = useScanInstalled();
 const updateMutation = useUpdateSoftware();
 const { isRunning, startOperation } = useOperations();
 const { enqueue, isActive: queueActive } = useUpdateQueue();
+const { data: lastScanData } = useLastScan();
 
 const showUpdateAllConfirm = ref(false);
 const showSingleUpdateConfirm = ref(false);
@@ -34,6 +35,13 @@ const updatablePackages = computed<PackageWithStatus[]>(() => {
 const updateCount = computed(() => updatablePackages.value.length);
 
 const hasScanned = computed(() => installedCount.value > 0);
+
+const lastScanLabel = computed(() => {
+  const ts = lastScanData.value?.last_scan_at;
+  if (!ts) return hasScanned.value ? `${installedCount.value} found` : "\u2014";
+  const date = new Date(ts + "Z");
+  return date.toLocaleDateString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+});
 
 function runScan() {
   if (!startOperation("scan", "Scanning installed software")) return;
@@ -100,7 +108,7 @@ function confirmSingleUpdate() {
           Last Scan
         </div>
         <div class="stat-value scan-val">
-          {{ hasScanned ? installedCount + " found" : "\u2014" }}
+          {{ lastScanLabel }}
         </div>
         <div class="stat-sub">
           {{ installedCount }} packages detected

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -4,8 +4,9 @@ import { useRouter } from "vue-router";
 import Button from "primevue/button";
 import ConfirmDialog from "../components/shared/ConfirmDialog.vue";
 import PackageIcon from "../components/shared/PackageIcon.vue";
-import { useSoftwareList, useScanInstalled, useUpdateAll, useActivity } from "../composables/useInvoke";
+import { useSoftwareList, useScanInstalled, useUpdateSoftware } from "../composables/useInvoke";
 import { useOperations } from "../composables/useOperations";
+import { useUpdateQueue } from "../composables/useUpdateQueue";
 import { logger } from "../utils/logger";
 import type { PackageWithStatus } from "../types/package";
 
@@ -13,11 +14,13 @@ const router = useRouter();
 const { data: software } = useSoftwareList(() => "all");
 const { data: installedSoftware } = useSoftwareList(() => "installed");
 const scanMutation = useScanInstalled();
-const updateAllMutation = useUpdateAll();
+const updateMutation = useUpdateSoftware();
 const { isRunning, startOperation } = useOperations();
-const { data: activity } = useActivity(10);
+const { enqueue, isActive: queueActive } = useUpdateQueue();
 
 const showUpdateAllConfirm = ref(false);
+const showSingleUpdateConfirm = ref(false);
+const pendingUpdatePkg = ref<PackageWithStatus | null>(null);
 
 const catalogCount = computed(() => software.value?.length ?? 0);
 
@@ -40,51 +43,20 @@ function runScan() {
 
 function confirmUpdateAll() {
   logger.debug("DashboardView", "update all clicked");
-  updateAllMutation.mutate();
+  enqueue(updatablePackages.value.map((p) => ({ id: p.id, name: p.name })));
 }
 
-interface ActivityRecord {
-  id: number;
-  package_id: string;
-  operation_type: string;
-  from_version: string | null;
-  to_version: string | null;
-  status: string;
-  duration_ms: number;
-  error_message: string | null;
-  created_at: string;
+function handleSingleUpdate(pkg: PackageWithStatus) {
+  pendingUpdatePkg.value = pkg;
+  showSingleUpdateConfirm.value = true;
 }
 
-const activityRecords = computed<ActivityRecord[]>(() =>
-  (activity.value ?? []) as ActivityRecord[],
-);
-
-function activityIcon(record: ActivityRecord): string {
-  if (record.status === "failed") return "pi-times-circle";
-  switch (record.operation_type) {
-    case "install": return "pi-download";
-    case "update": return "pi-arrow-up";
-    case "uninstall": return "pi-trash";
-    default: return "pi-info-circle";
-  }
-}
-
-function activityLabel(record: ActivityRecord): string {
-  const verb = record.operation_type === "install" ? "Installed"
-    : record.operation_type === "update" ? "Updated"
-    : record.operation_type === "uninstall" ? "Uninstalled"
-    : record.operation_type;
-  if (record.status === "failed") return `${verb} ${record.package_id} (failed)`;
-  return `${verb} ${record.package_id}`;
-}
-
-function activityDetail(record: ActivityRecord): string {
-  const parts: string[] = [];
-  if (record.to_version) parts.push(`v${record.to_version}`);
-  if (record.from_version && record.to_version) parts[0] = `${record.from_version} \u2192 ${record.to_version}`;
-  const date = new Date(record.created_at);
-  parts.push(date.toLocaleDateString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" }));
-  return parts.join(" \u00B7 ");
+function confirmSingleUpdate() {
+  const pkg = pendingUpdatePkg.value;
+  if (!pkg || !startOperation(pkg.id, `Updating ${pkg.name}`)) return;
+  logger.debug("DashboardView", `update clicked: ${pkg.id}`);
+  updateMutation.mutate(pkg.id);
+  pendingUpdatePkg.value = null;
 }
 
 </script>
@@ -183,7 +155,8 @@ function activityDetail(record: ActivityRecord): string {
             label="Update"
             severity="warn"
             size="small"
-            @click.stop="showUpdateAllConfirm = true"
+            :disabled="isRunning || queueActive"
+            @click.stop="handleSingleUpdate(pkg)"
           />
         </div>
         <div class="upd-footer">
@@ -204,7 +177,7 @@ function activityDetail(record: ActivityRecord): string {
       <Button
         label="Scan Installed"
         icon="pi pi-refresh"
-        :disabled="isRunning"
+        :disabled="isRunning || queueActive"
         @click="runScan"
       />
       <Button
@@ -213,69 +186,9 @@ function activityDetail(record: ActivityRecord): string {
         icon="pi pi-download"
         severity="secondary"
         outlined
-        :disabled="isRunning"
+        :disabled="isRunning || queueActive"
         @click="showUpdateAllConfirm = true"
       />
-    </div>
-
-    <!-- Activity feed -->
-    <div class="section-title">
-      Recent Activity
-    </div>
-    <div class="card activity-card">
-      <template v-if="activityRecords.length > 0">
-        <div
-          v-for="record in activityRecords"
-          :key="record.id"
-          class="act-row"
-        >
-          <div
-            class="act-icon"
-            :class="record.status === 'failed' ? 'act-error' : 'act-ok'"
-          >
-            <i :class="'pi ' + activityIcon(record)" />
-          </div>
-          <div class="act-text">
-            <div class="act-name">
-              {{ activityLabel(record) }}
-            </div>
-            <div class="act-det">
-              {{ activityDetail(record) }}
-            </div>
-          </div>
-        </div>
-      </template>
-      <template v-else-if="hasScanned">
-        <div class="act-row">
-          <div class="act-icon act-scan">
-            <i class="pi pi-search" />
-          </div>
-          <div class="act-text">
-            <div class="act-name">
-              {{ installedCount }} packages detected
-            </div>
-            <div class="act-det">
-              {{ updateCount }} update{{ updateCount === 1 ? "" : "s" }} available
-            </div>
-          </div>
-        </div>
-      </template>
-      <div
-        v-else
-        class="act-row"
-      >
-        <div class="act-icon act-scan">
-          <i class="pi pi-info-circle" />
-        </div>
-        <div class="act-text">
-          <div class="act-name">
-            No activity yet
-          </div>
-          <div class="act-det">
-            Run a scan to detect installed software
-          </div>
-        </div>
-      </div>
     </div>
 
     <ConfirmDialog
@@ -286,6 +199,16 @@ function activityDetail(record: ActivityRecord): string {
       confirm-label="Update All"
       severity="warn"
       @confirm="confirmUpdateAll"
+    />
+
+    <ConfirmDialog
+      v-model:visible="showSingleUpdateConfirm"
+      title="Update Package"
+      :message="`Update ${pendingUpdatePkg?.name} to ${pendingUpdatePkg?.latest_version}?`"
+      icon="pi-arrow-up"
+      confirm-label="Update"
+      severity="warn"
+      @confirm="confirmSingleUpdate"
     />
   </div>
 </template>
@@ -415,68 +338,4 @@ function activityDetail(record: ActivityRecord): string {
   gap: 10px;
 }
 
-/* Activity card */
-.activity-card {
-  overflow: hidden;
-}
-
-.act-row {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 11px 16px;
-  border-bottom: 1px solid var(--p-surface-700);
-}
-
-.act-row:last-child {
-  border-bottom: none;
-}
-
-.act-icon {
-  width: 30px;
-  height: 30px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  font-size: 12px;
-  flex-shrink: 0;
-}
-
-.act-icon.act-install {
-  background: color-mix(in srgb, var(--p-green-500) 20%, transparent);
-  color: var(--p-green-400);
-}
-
-.act-icon.act-update {
-  background: color-mix(in srgb, var(--p-yellow-500) 15%, transparent);
-  color: var(--p-yellow-400);
-}
-
-.act-icon.act-scan {
-  background: color-mix(in srgb, var(--p-indigo-500) 20%, transparent);
-  color: var(--p-indigo-400);
-}
-
-.act-text {
-  flex: 1;
-  min-width: 0;
-}
-
-.act-name {
-  font-size: 13px;
-  color: var(--p-surface-0);
-}
-
-.act-det {
-  font-size: 11px;
-  color: var(--p-surface-500);
-}
-
-.act-time {
-  font-size: 11px;
-  color: var(--p-surface-600);
-  flex-shrink: 0;
-  margin-left: auto;
-}
 </style>

--- a/frontend/src/views/InstalledView.vue
+++ b/frontend/src/views/InstalledView.vue
@@ -10,6 +10,7 @@ import ConfirmDialog from "../components/shared/ConfirmDialog.vue";
 import EmptyState from "../components/shared/EmptyState.vue";
 import { useSoftwareList, useUpdateSoftware, useScanInstalled, useCreateBackup } from "../composables/useInvoke";
 import { useOperations } from "../composables/useOperations";
+import { useUpdateQueue } from "../composables/useUpdateQueue";
 import type { PackageWithStatus } from "../types/package";
 
 const router = useRouter();
@@ -18,6 +19,7 @@ const updateMutation = useUpdateSoftware();
 const scanMutation = useScanInstalled();
 const backupMutation = useCreateBackup();
 const { startOperation, isRunning } = useOperations();
+const { enqueue, isActive: queueActive } = useUpdateQueue();
 
 const searchFilter = ref("");
 const showUpdateConfirm = ref(false);
@@ -57,10 +59,7 @@ function confirmUpdate() {
 }
 
 function confirmUpdateAll() {
-  if (!startOperation("update-all", "Updating all packages")) return;
-  for (const pkg of updatable.value) {
-    updateMutation.mutate(pkg.id);
-  }
+  enqueue(updatable.value.map((p) => ({ id: p.id, name: p.name })));
 }
 
 function confirmScan() {
@@ -95,7 +94,7 @@ function handleBackup(pkg: PackageWithStatus) {
         icon="pi pi-download"
         severity="warn"
         size="small"
-        :disabled="isRunning"
+        :disabled="isRunning || queueActive"
         @click="showUpdateAllConfirm = true"
       />
       <Button
@@ -104,7 +103,7 @@ function handleBackup(pkg: PackageWithStatus) {
         severity="secondary"
         outlined
         size="small"
-        :disabled="isRunning"
+        :disabled="isRunning || queueActive"
         @click="confirmScan"
       />
     </div>
@@ -131,6 +130,7 @@ function handleBackup(pkg: PackageWithStatus) {
           v-for="pkg in updatable"
           :key="pkg.id"
           :pkg="pkg"
+          :actions-disabled="isRunning || queueActive"
           @update="handleUpdate(pkg)"
           @backup="handleBackup(pkg)"
           @detail="router.push({ name: 'package-detail', params: { id: pkg.id } })"
@@ -147,6 +147,7 @@ function handleBackup(pkg: PackageWithStatus) {
           v-for="pkg in upToDate"
           :key="pkg.id"
           :pkg="pkg"
+          :actions-disabled="isRunning || queueActive"
           @backup="handleBackup(pkg)"
           @detail="router.push({ name: 'package-detail', params: { id: pkg.id } })"
         />

--- a/frontend/src/views/PackageDetailView.vue
+++ b/frontend/src/views/PackageDetailView.vue
@@ -14,8 +14,9 @@ import TechnicalTab from "../components/detail/TechnicalTab.vue";
 import ConfirmDialog from "../components/shared/ConfirmDialog.vue";
 import EmptyState from "../components/shared/EmptyState.vue";
 import { useSoftwareList, useVersions, useInstallSoftware, useUpdateSoftware, useCreateBackup } from "../composables/useInvoke";
+import { useOperations } from "../composables/useOperations";
+import { useUpdateQueue } from "../composables/useUpdateQueue";
 import { logger } from "../utils/logger";
-// useOperations not needed here — core events handle operation lifecycle
 import type { PackageWithStatus, VersionEntry } from "../types/package";
 
 const props = defineProps<{
@@ -28,6 +29,9 @@ const { data: versions } = useVersions(() => props.id);
 const installMutation = useInstallSoftware();
 const updateMutation = useUpdateSoftware();
 const backupMutation = useCreateBackup();
+const { isRunning } = useOperations();
+const { isActive: queueActive } = useUpdateQueue();
+const actionsDisabled = computed(() => isRunning.value || queueActive.value);
 
 const showBackupConfirm = ref(false);
 const tabsReady = ref(false);
@@ -94,6 +98,7 @@ function confirmBackup() {
     <template v-else-if="pkg">
       <DetailHero
         :pkg="pkg"
+        :actions-disabled="actionsDisabled"
         @install="handleInstall"
         @update="handleUpdate"
         @backup="handleBackup"

--- a/frontend/src/views/PackageDetailView.vue
+++ b/frontend/src/views/PackageDetailView.vue
@@ -134,6 +134,7 @@ function confirmBackup() {
               <VersionsTab
                 :versions="(versions as VersionEntry[] | undefined) ?? []"
                 :installed-version="pkg.installed_version ?? null"
+                :actions-disabled="actionsDisabled"
                 @install="handleInstall"
               />
             </TabPanel>
@@ -141,6 +142,7 @@ function confirmBackup() {
               <BackupTab
                 :package-id="pkg.id"
                 :config-paths="pkg.backup?.config_paths"
+                :actions-disabled="actionsDisabled"
                 @backup="handleBackup"
               />
             </TabPanel>


### PR DESCRIPTION
## Summary

- Replace backend `update_all` with a frontend-managed sequential queue (`useUpdateQueue` composable)
- Each package is updated one at a time via `update_software(id)`, with per-package progress in the OperationsDock
- Process-blocking events during queue show a "warn" toast and skip to the next package (instead of 5 error toasts at once)
- All action buttons (Install, Update, Backup, Scan) disabled while any operation is active
- Per-row "Update" button on Dashboard now triggers single-package update (was incorrectly firing update-all)
- Remove low-value activity feed from Dashboard
- Fix InstalledView `confirmUpdateAll()` which was firing all mutations simultaneously without awaiting

## What's new

- `useUpdateQueue.ts` — singleton composable with reactive queue, sequential `enqueue()`, cancel support
- `OperationsDock.vue` — shows queue header "Updating 2/5: NINA" above per-package progress bar
- `DetailHero.vue` / `PackageRow.vue` — new `actionsDisabled` prop disables Install/Update/Backup buttons during operations

## Test plan

- [ ] Click "Update All" with 3+ updates available -- dock shows "Updating 1/N: {pkg}", packages process one at a time
- [ ] Process-blocking shows max one "warn" toast per package, queue advances
- [ ] Cancel button during queue cancels current operation and marks remaining as cancelled
- [ ] Per-row "Update" on Dashboard shows single-package confirm dialog
- [ ] All Install/Update/Backup/Scan buttons disabled while an operation runs
- [ ] After queue completes, dock shows summary "N succeeded, N failed" with dismiss button
- [ ] Single-package update (from detail page or installed view) still works as before
