### PR TITLE
feat: show install method and config in Technical tab

### DIFF
--- a/crates/astro-up-gui/src/commands.rs
+++ b/crates/astro-up-gui/src/commands.rs
@@ -224,7 +224,7 @@ fn try_list_software(
         _ => reader.list_all()?,
     };
 
-    // Enrich each package with installed version, latest version, and update status
+    // Enrich each package with installed version, latest version, update status, and install config
     let enriched: Vec<serde_json::Value> = packages
         .iter()
         .map(|pkg| {
@@ -264,6 +264,13 @@ fn try_list_software(
                     "detection".into(),
                     serde_json::to_value(detection).unwrap_or_default(),
                 );
+            }
+
+            // Include install config from the catalog (method, scope, elevation, etc.)
+            if let Ok(Some(install)) = reader.install_config(&pkg.id) {
+                if let Ok(install_val) = serde_json::to_value(&install) {
+                    obj.insert("install".into(), install_val);
+                }
             }
 
             val

--- a/frontend/src/components/detail/TechnicalTab.vue
+++ b/frontend/src/components/detail/TechnicalTab.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import type { PackageWithStatus } from "../../types/package";
+import type { PackageWithStatus, InstallMethod, InstallScope, InstallElevation } from "../../types/package";
 
 defineProps<{
   pkg: PackageWithStatus;
@@ -18,6 +18,30 @@ function detectionDetails(pkg: PackageWithStatus): Record<string, string> {
       return { Status: "Unavailable", Reason: pkg.detection.reason };
   }
 }
+
+const methodLabels: Record<InstallMethod, string> = {
+  exe: "Exe",
+  msi: "MSI",
+  inno_setup: "InnoSetup",
+  nsis: "NSIS",
+  wix: "WiX",
+  burn: "Burn",
+  zip: "Zip",
+  portable: "Portable",
+  download_only: "Download Only",
+};
+
+const scopeLabels: Record<InstallScope, string> = {
+  machine: "Machine",
+  user: "User",
+  either: "Either",
+};
+
+const elevationLabels: Record<InstallElevation, string> = {
+  required: "Required",
+  prohibited: "Prohibited",
+  self: "Self",
+};
 </script>
 
 <template>
@@ -38,9 +62,45 @@ function detectionDetails(pkg: PackageWithStatus): Record<string, string> {
       </div>
     </section>
 
+    <section
+      v-if="pkg.install"
+      class="tech-section"
+    >
+      <h3 class="section-title">
+        Install Method
+      </h3>
+      <div class="tech-grid">
+        <div class="tech-item">
+          <span class="tech-label">Method</span>
+          <span class="tech-value">{{ methodLabels[pkg.install.method] ?? pkg.install.method }}</span>
+        </div>
+        <div
+          v-if="pkg.install.scope"
+          class="tech-item"
+        >
+          <span class="tech-label">Scope</span>
+          <span class="tech-value">{{ scopeLabels[pkg.install.scope] ?? pkg.install.scope }}</span>
+        </div>
+        <div
+          v-if="pkg.install.elevation"
+          class="tech-item"
+        >
+          <span class="tech-label">Elevation</span>
+          <span class="tech-value">{{ elevationLabels[pkg.install.elevation] ?? pkg.install.elevation }}</span>
+        </div>
+        <div
+          v-if="pkg.install.zip_wrapped"
+          class="tech-item"
+        >
+          <span class="tech-label">Zip Wrapped</span>
+          <span class="tech-value">Yes</span>
+        </div>
+      </div>
+    </section>
+
     <section class="tech-section">
       <h3 class="section-title">
-        Installation
+        Package Info
       </h3>
       <div class="tech-grid">
         <div class="tech-item">

--- a/frontend/src/types/package.ts
+++ b/frontend/src/types/package.ts
@@ -60,10 +60,42 @@ export interface BackupConfig {
   config_paths: string[];
 }
 
+export type InstallMethod =
+  | "exe"
+  | "msi"
+  | "inno_setup"
+  | "nsis"
+  | "wix"
+  | "burn"
+  | "zip"
+  | "portable"
+  | "download_only";
+
+export type InstallScope = "machine" | "user" | "either";
+
+export type InstallElevation = "required" | "prohibited" | "self";
+
+export interface InstallConfig {
+  method: InstallMethod;
+  zip_wrapped: boolean;
+  zip_inner_path?: string | null;
+  scope?: InstallScope | null;
+  elevation?: InstallElevation | null;
+  upgrade_behavior?: string | null;
+  install_modes: string[];
+  success_codes: number[];
+  pre_install: string[];
+  post_install: string[];
+  switches?: Record<string, unknown> | null;
+  known_exit_codes: Record<string, string>;
+  timeout?: number | null;
+}
+
 export interface PackageWithStatus extends PackageSummary {
   installed_version?: string | null;
   latest_version?: string;
   update_available?: boolean;
   detection?: DetectionResult;
   backup?: BackupConfig | null;
+  install?: InstallConfig | null;
 }


### PR DESCRIPTION
## Summary

- Add install config data (method, scope, elevation, zip-wrapped) to the package detail Technical tab
- Backend `list_software` now enriches each package with install config from the catalog's `install` table
- Frontend displays a new "Install Method" section with human-readable labels (e.g., "InnoSetup", "NSIS", "MSI")
- Rename the existing "Installation" section to "Package Info" for clarity

## Test plan

- [ ] Open a package detail view and verify the Technical tab shows an "Install Method" section
- [ ] Confirm method label displays correctly (e.g., "InnoSetup" not "inno_setup")
- [ ] Verify scope/elevation/zip-wrapped only appear when the data is present
- [ ] Verify packages without install config don't show the "Install Method" section
- [ ] Run `vue-tsc --noEmit` to confirm type safety
