### PR TITLE
feat: show download path in operations dock for DownloadOnly packages

### DIFF
--- a/crates/astro-up-core/src/engine/orchestrator.rs
+++ b/crates/astro-up-core/src/engine/orchestrator.rs
@@ -577,13 +577,12 @@ where
         };
 
         // For DownloadOnly packages, surface the download directory in the event
-        let download_path = if install_request.install_config.method
-            == crate::types::InstallMethod::DownloadOnly
-        {
-            result_path.map(|p| p.to_string_lossy().into_owned())
-        } else {
-            None
-        };
+        let download_path =
+            if install_request.install_config.method == crate::types::InstallMethod::DownloadOnly {
+                result_path.map(|p| p.to_string_lossy().into_owned())
+            } else {
+                None
+            };
 
         check_cancel!();
 

--- a/crates/astro-up-core/src/engine/orchestrator.rs
+++ b/crates/astro-up-core/src/engine/orchestrator.rs
@@ -299,6 +299,7 @@ where
                         package_id: pkg_id.clone(),
                         status: "cancelled".into(),
                         error: None,
+                        download_path: None,
                     });
                     return PackageResult {
                         package_id: pkg_id.clone(),
@@ -358,6 +359,7 @@ where
                 package_id: pkg_id.clone(),
                 status: "failed".into(),
                 error: Some(format!("disk space check: {e}")),
+                download_path: None,
             });
             return PackageResult {
                 package_id: pkg_id.clone(),
@@ -390,6 +392,7 @@ where
                                 package_id: pkg_id.clone(),
                                 status: "failed".into(),
                                 error: Some(err_msg.clone()),
+                                download_path: None,
                             });
                             return PackageResult {
                                 package_id: pkg_id.clone(),
@@ -418,6 +421,7 @@ where
                 package_id: pkg_id.clone(),
                 status: "failed".into(),
                 error: Some(err_msg.clone()),
+                download_path: None,
             });
             return PackageResult {
                 package_id: pkg_id.clone(),
@@ -450,6 +454,7 @@ where
                     package_id: pkg_id.clone(),
                     status: "failed".into(),
                     error: Some(err_msg.clone()),
+                    download_path: None,
                 });
                 return PackageResult {
                     package_id: pkg_id.clone(),
@@ -530,6 +535,7 @@ where
                     package_id: pkg_id.clone(),
                     status: "failed".into(),
                     error: Some(err_msg.clone()),
+                    download_path: None,
                 });
                 return PackageResult {
                     package_id: pkg_id.clone(),
@@ -543,16 +549,17 @@ where
             }
         };
 
-        // Map install result to operation status
-        let install_status = match install_result {
-            crate::install::types::InstallResult::SuccessRebootRequired { .. } => {
-                super::history::OperationStatus::RebootPending
+        // Map install result to operation status and extract result path
+        let (install_status, result_path) = match install_result {
+            crate::install::types::InstallResult::SuccessRebootRequired { path } => {
+                (super::history::OperationStatus::RebootPending, path)
             }
             crate::install::types::InstallResult::Cancelled => {
                 on_event(Event::PackageComplete {
                     package_id: pkg_id.clone(),
                     status: "cancelled".into(),
                     error: None,
+                    download_path: None,
                 });
                 return PackageResult {
                     package_id: pkg_id.clone(),
@@ -564,9 +571,18 @@ where
                     backup_path,
                 };
             }
-            crate::install::types::InstallResult::Success { .. } => {
-                super::history::OperationStatus::Success
+            crate::install::types::InstallResult::Success { path } => {
+                (super::history::OperationStatus::Success, path)
             }
+        };
+
+        // For DownloadOnly packages, surface the download directory in the event
+        let download_path = if install_request.install_config.method
+            == crate::types::InstallMethod::DownloadOnly
+        {
+            result_path.map(|p| p.to_string_lossy().into_owned())
+        } else {
+            None
         };
 
         check_cancel!();
@@ -636,6 +652,7 @@ where
             package_id: pkg_id.clone(),
             status: status_str.into(),
             error: None,
+            download_path,
         });
 
         // 9. Record to operation history (best-effort — don't fail pipeline)

--- a/crates/astro-up-core/src/events.rs
+++ b/crates/astro-up-core/src/events.rs
@@ -104,6 +104,9 @@ pub enum Event {
         /// Error details when status is "failed".
         #[serde(skip_serializing_if = "Option::is_none")]
         error: Option<String>,
+        /// Directory where the installer was downloaded (DownloadOnly packages).
+        #[serde(skip_serializing_if = "Option::is_none")]
+        download_path: Option<String>,
     },
     /// Package skipped due to policy or dependency failure.
     PackageSkipped {
@@ -219,6 +222,7 @@ mod tests {
                 package_id: PackageId::new("nina-app").unwrap(),
                 status: "succeeded".into(),
                 error: None,
+                download_path: None,
             },
             Event::PackageSkipped {
                 package_id: PackageId::new("phd2").unwrap(),

--- a/crates/astro-up-core/src/install/mod.rs
+++ b/crates/astro-up-core/src/install/mod.rs
@@ -388,16 +388,20 @@ impl InstallerService {
     /// Handles DownloadOnly packages: opens the containing folder on Windows.
     /// On non-Windows, returns `Success` without opening a folder (no desktop
     /// environment assumed in CI/cross-compile targets).
+    ///
+    /// Returns the parent directory of the installer so the UI can show the
+    /// download location to the user.
     #[allow(unused_variables)]
     async fn handle_download_only(
         &self,
         installer_path: &std::path::Path,
     ) -> Result<InstallResult, CoreError> {
+        let parent = installer_path.parent().map(std::path::Path::to_path_buf);
         #[cfg(windows)]
-        if let Some(parent) = installer_path.parent() {
-            std::process::Command::new("explorer").arg(parent).spawn()?;
+        if let Some(ref dir) = parent {
+            std::process::Command::new("explorer").arg(dir).spawn()?;
         }
-        Ok(InstallResult::Success { path: None })
+        Ok(InstallResult::Success { path: parent })
     }
 
     #[instrument(skip_all, fields(package = %request.package_id))]

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -156,6 +156,9 @@ useCoreEvents((event: CoreEvent) => {
       failOperation(`${event.data.package_id}: ${reason}`);
     } else {
       if (queueActive.value) markCurrentComplete();
+      if (event.data.download_path) {
+        addStep("info", `Downloaded to: ${event.data.download_path}`);
+      }
       completeOperation();
     }
   } else if (event.type === "orchestration_complete") {

--- a/frontend/src/components/layout/OperationsDock.vue
+++ b/frontend/src/components/layout/OperationsDock.vue
@@ -6,6 +6,24 @@ import { useOperations } from "../../composables/useOperations";
 import { useUpdateQueue } from "../../composables/useUpdateQueue";
 import { useCancelOperation } from "../../composables/useInvoke";
 
+const DOWNLOAD_PATH_PREFIX = "Downloaded to: ";
+
+function extractDownloadPath(message: string): string | null {
+  if (message.startsWith(DOWNLOAD_PATH_PREFIX)) {
+    return message.slice(DOWNLOAD_PATH_PREFIX.length);
+  }
+  return null;
+}
+
+async function openDownloadFolder(path: string) {
+  try {
+    const { open: openPath } = await import("@tauri-apps/plugin-shell");
+    await openPath(path);
+  } catch {
+    // Not running inside Tauri or path invalid
+  }
+}
+
 const { operation, dismissOperation, cancelOperation } = useOperations();
 const { isActive: queueActive, progress: queueProgress, queueLabel, summary: queueSummary, items: queueItems, cancelQueue, clearQueue } = useUpdateQueue();
 const cancelMutation = useCancelOperation();
@@ -165,7 +183,18 @@ watch(
           :class="step.level"
         >
           <span class="step-time">{{ step.timestamp.slice(11, 19) }}</span>
-          <span class="step-message">{{ step.message }}</span>
+          <span
+            v-if="extractDownloadPath(step.message)"
+            class="step-message step-link"
+            title="Open folder"
+            @click.stop="openDownloadFolder(extractDownloadPath(step.message)!)"
+          >
+            <i class="pi pi-folder-open" /> {{ step.message }}
+          </span>
+          <span
+            v-else
+            class="step-message"
+          >{{ step.message }}</span>
         </div>
       </div>
     </template>
@@ -257,6 +286,7 @@ watch(
   flex-shrink: 0;
 }
 
+<<<<<<< HEAD
 .ops-queue-bar {
   display: flex;
   align-items: center;
@@ -276,5 +306,21 @@ watch(
 .ops-queue-summary {
   color: var(--p-surface-300);
   background: transparent;
+}
+
+.step-link {
+  cursor: pointer;
+  color: var(--p-primary-400);
+  text-decoration: underline;
+  text-decoration-style: dotted;
+}
+
+.step-link:hover {
+  color: var(--p-primary-300);
+}
+
+.step-link .pi {
+  font-size: 10px;
+  margin-right: 2px;
 }
 </style>

--- a/frontend/src/components/layout/OperationsDock.vue
+++ b/frontend/src/components/layout/OperationsDock.vue
@@ -286,7 +286,6 @@ watch(
   flex-shrink: 0;
 }
 
-<<<<<<< HEAD
 .ops-queue-bar {
   display: flex;
   align-items: center;

--- a/frontend/src/types/commands.ts
+++ b/frontend/src/types/commands.ts
@@ -41,7 +41,7 @@ export type CoreEvent =
     }
   | {
       type: "package_complete";
-      data: { package_id: string; status: string; error?: string };
+      data: { package_id: string; status: string; error?: string; download_path?: string };
     }
   | {
       type: "package_skipped";


### PR DESCRIPTION
## Summary

- Add `download_path` field to the `PackageComplete` event so the frontend knows where DownloadOnly packages were saved
- `handle_download_only` now returns the parent directory of the installer file instead of `None`
- The orchestrator threads the path through only when the install method is `DownloadOnly`
- The operations dock renders "Downloaded to:" steps as clickable links that open the folder via `@tauri-apps/plugin-shell`

## What's new

When a DownloadOnly package (e.g., a manual-install tool) completes, the operations dock now shows:
- A "Downloaded to: C:\Users\...\downloads" info step
- The step is styled as a clickable link with a folder icon
- Clicking it opens the download directory in Windows Explorer (via Tauri shell plugin)

## Test plan

- [x] `cargo clippy -p astro-up-core -p astro-up-cli -- -D warnings` passes
- [x] `cargo test -p astro-up-core --lib` passes (243 tests)
- [x] `vue-tsc --noEmit` passes
- [x] Snapshot test `all_events_snapshot` passes (field is `skip_serializing_if` so existing snapshots unaffected)
- [ ] Manual: trigger a DownloadOnly package install and verify the path appears in the operations dock
- [ ] Manual: click the download path link and verify the folder opens

## Spec Context

Standalone enhancement, not part of a spec.
