### PR TITLE
fix: catalog reader drops wmi_apps detection configs

### DIFF
--- a/crates/astro-up-core/src/catalog/reader.rs
+++ b/crates/astro-up-core/src/catalog/reader.rs
@@ -510,6 +510,7 @@ fn parse_detection_method(method_str: &str) -> Option<crate::types::DetectionMet
         "registry" => Some(crate::types::DetectionMethod::Registry),
         "file" | "pe_file" => Some(crate::types::DetectionMethod::PeFile),
         "wmi" => Some(crate::types::DetectionMethod::Wmi),
+        "wmi_apps" => Some(crate::types::DetectionMethod::WmiApps),
         "driver_store" => Some(crate::types::DetectionMethod::DriverStore),
         "ascom_profile" => Some(crate::types::DetectionMethod::AscomProfile),
         "file_exists" => Some(crate::types::DetectionMethod::FileExists),

--- a/crates/astro-up-core/tests/catalog_detection_roundtrip.rs
+++ b/crates/astro-up-core/tests/catalog_detection_roundtrip.rs
@@ -323,3 +323,168 @@ fn list_all_with_detection_populates_config() {
     let switches = install.switches.as_ref().expect("switches should exist");
     assert!(!switches.silent.is_empty());
 }
+
+#[test]
+fn wmi_apps_detection_method_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("catalog.db");
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute_batch(
+        "
+        CREATE TABLE packages (
+            id TEXT PRIMARY KEY, manifest_version INTEGER NOT NULL,
+            name TEXT NOT NULL, description TEXT, publisher TEXT, homepage TEXT,
+            category TEXT NOT NULL, [type] TEXT NOT NULL, slug TEXT NOT NULL,
+            license TEXT, tags TEXT, aliases TEXT, dependencies TEXT, icon_base64 TEXT
+        );
+        CREATE TABLE versions (
+            package_id TEXT NOT NULL, version TEXT NOT NULL, url TEXT NOT NULL,
+            sha256 TEXT, discovered_at TEXT NOT NULL, release_notes_url TEXT,
+            pre_release INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (package_id, version)
+        );
+        CREATE TABLE detection (
+            package_id TEXT PRIMARY KEY, method TEXT NOT NULL, file_path TEXT,
+            registry_key TEXT, registry_value TEXT, version_regex TEXT,
+            product_code TEXT, upgrade_code TEXT, inf_provider TEXT,
+            device_class TEXT, inf_name TEXT, fallback_config TEXT
+        );
+        CREATE TABLE install (
+            package_id TEXT PRIMARY KEY, method TEXT NOT NULL,
+            scope TEXT, elevation INTEGER NOT NULL DEFAULT 0,
+            switches TEXT, exit_codes TEXT, success_codes TEXT
+        );
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE VIRTUAL TABLE packages_fts USING fts5(
+            name, description, tags, aliases, publisher,
+            content='packages', content_rowid='rowid'
+        );
+        ",
+    )
+    .unwrap();
+
+    // Insert ASI Studio-like package with wmi_apps primary + file_exists fallback
+    conn.execute(
+        "INSERT INTO packages VALUES (?1,1,'ZWO ASIStudio','ZWO imaging suite','ZWO','https://zwo.com','capture','application','zwo-asistudio','Proprietary',NULL,'[\"ASIStudio\"]',NULL,NULL)",
+        params!["zwo-asistudio"],
+    ).unwrap();
+    conn.execute_batch(
+        "INSERT INTO packages_fts(rowid, name, description, tags, aliases, publisher) SELECT rowid, name, description, tags, aliases, publisher FROM packages;",
+    ).unwrap();
+    conn.execute(
+        "INSERT INTO versions VALUES ('zwo-asistudio','1.8.0','https://example.com/asistudio.exe',NULL,'2026-01-01T00:00:00Z',NULL,0)",
+        [],
+    ).unwrap();
+
+    let fallback_json = serde_json::json!({
+        "method": "file_exists",
+        "file_path": "C:\\Program Files\\ASIStudio\\ASIStudio.exe"
+    });
+    conn.execute(
+        "INSERT INTO detection (package_id, method, fallback_config) VALUES ('zwo-asistudio','wmi_apps',?1)",
+        params![fallback_json.to_string()],
+    ).unwrap();
+    conn.execute("INSERT INTO meta VALUES ('schema_version','1')", [])
+        .unwrap();
+    conn.execute(
+        "INSERT INTO meta VALUES ('compiled_at','2026-03-30T12:00:00Z')",
+        [],
+    )
+    .unwrap();
+
+    let reader = SqliteCatalogReader::open(&db_path).unwrap();
+    let id: PackageId = "zwo-asistudio".parse().unwrap();
+    let config = reader.detection_config(&id).unwrap();
+    assert!(
+        config.is_some(),
+        "wmi_apps detection config should be parsed"
+    );
+
+    let config = config.unwrap();
+    assert_eq!(config.method, DetectionMethod::WmiApps);
+
+    // Verify fallback chain
+    let fallback = config.fallback.as_ref().expect("fallback should exist");
+    assert_eq!(fallback.method, DetectionMethod::FileExists);
+    assert_eq!(
+        fallback.file_path.as_deref(),
+        Some("C:\\Program Files\\ASIStudio\\ASIStudio.exe")
+    );
+}
+
+#[test]
+fn file_exists_detection_method_roundtrip() {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("catalog.db");
+    let conn = Connection::open(&db_path).unwrap();
+
+    conn.execute_batch(
+        "
+        CREATE TABLE packages (
+            id TEXT PRIMARY KEY, manifest_version INTEGER NOT NULL,
+            name TEXT NOT NULL, description TEXT, publisher TEXT, homepage TEXT,
+            category TEXT NOT NULL, [type] TEXT NOT NULL, slug TEXT NOT NULL,
+            license TEXT, tags TEXT, aliases TEXT, dependencies TEXT, icon_base64 TEXT
+        );
+        CREATE TABLE versions (
+            package_id TEXT NOT NULL, version TEXT NOT NULL, url TEXT NOT NULL,
+            sha256 TEXT, discovered_at TEXT NOT NULL, release_notes_url TEXT,
+            pre_release INTEGER NOT NULL DEFAULT 0, PRIMARY KEY (package_id, version)
+        );
+        CREATE TABLE detection (
+            package_id TEXT PRIMARY KEY, method TEXT NOT NULL, file_path TEXT,
+            registry_key TEXT, registry_value TEXT, version_regex TEXT,
+            product_code TEXT, upgrade_code TEXT, inf_provider TEXT,
+            device_class TEXT, inf_name TEXT, fallback_config TEXT
+        );
+        CREATE TABLE install (
+            package_id TEXT PRIMARY KEY, method TEXT NOT NULL,
+            scope TEXT, elevation INTEGER NOT NULL DEFAULT 0,
+            switches TEXT, exit_codes TEXT, success_codes TEXT
+        );
+        CREATE TABLE meta (key TEXT PRIMARY KEY, value TEXT NOT NULL);
+        CREATE VIRTUAL TABLE packages_fts USING fts5(
+            name, description, tags, aliases, publisher,
+            content='packages', content_rowid='rowid'
+        );
+        ",
+    )
+    .unwrap();
+
+    // Insert ASTAP database-like package with file_exists detection
+    conn.execute(
+        "INSERT INTO packages VALUES (?1,1,'ASTAP D50 Star Database','Large star database','ASTAP','https://hnsky.org','platesolving','database','astap-d50','Freeware',NULL,NULL,NULL,NULL)",
+        params!["astap-d50"],
+    ).unwrap();
+    conn.execute_batch(
+        "INSERT INTO packages_fts(rowid, name, description, tags, aliases, publisher) SELECT rowid, name, description, tags, aliases, publisher FROM packages;",
+    ).unwrap();
+    conn.execute(
+        "INSERT INTO versions VALUES ('astap-d50','2024.01.01','https://example.com/d50.exe',NULL,'2026-01-01T00:00:00Z',NULL,0)",
+        [],
+    ).unwrap();
+    conn.execute(
+        "INSERT INTO detection (package_id, method, file_path) VALUES ('astap-d50','file_exists','{config_dir}/astap/d50')",
+        [],
+    ).unwrap();
+    conn.execute("INSERT INTO meta VALUES ('schema_version','1')", [])
+        .unwrap();
+    conn.execute(
+        "INSERT INTO meta VALUES ('compiled_at','2026-03-30T12:00:00Z')",
+        [],
+    )
+    .unwrap();
+
+    let reader = SqliteCatalogReader::open(&db_path).unwrap();
+    let id: PackageId = "astap-d50".parse().unwrap();
+    let config = reader.detection_config(&id).unwrap();
+    assert!(
+        config.is_some(),
+        "file_exists detection config should be parsed"
+    );
+
+    let config = config.unwrap();
+    assert_eq!(config.method, DetectionMethod::FileExists);
+    assert_eq!(config.file_path.as_deref(), Some("{config_dir}/astap/d50"));
+    assert!(config.fallback.is_none());
+}

--- a/crates/astro-up-core/tests/create_fixture_catalog.rs
+++ b/crates/astro-up-core/tests/create_fixture_catalog.rs
@@ -279,6 +279,20 @@ fn create_fixture_catalog() {
             None,
             None,
         ),
+        (
+            "astap",
+            "registry",
+            None,
+            Some("AppName=ASTAP, the Astrometric STAcking Program,~D52A8A79_is1"),
+            Some("DisplayVersion"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(r#"{"method":"pe_file","file_path":"C:\\Program Files\\astap\\astap.exe"}"#),
+        ),
     ];
 
     for (


### PR DESCRIPTION
## Summary

- `parse_detection_method()` in `catalog/reader.rs` was missing the `"wmi_apps"` case, silently dropping detection configs for any package using `wmi_apps` as its primary method (e.g., ASI Studio)
- The fallback chain was also lost, so `file_exists` fallbacks never ran for affected packages
- Adds regression tests for `wmi_apps` and `file_exists` round-trips through `SqliteCatalogReader`
- Adds ASTAP detection config to the fixture catalog generator (was missing)

### Root cause

When a catalog entry has `method = "wmi_apps"` in the detection table, `parse_detection_method()` returned `None` (unknown method), which caused `detection_config()` to return `Ok(None)`. The scanner then fell through to the generic WMI fallback (which works by name matching), but lost the manifest-defined fallback chain entirely.

### Affected packages (in astro-up-manifests)

| Package | Primary method | Fallback | Impact |
|---------|---------------|----------|--------|
| `zwo-asistudio` | `wmi_apps` | `file_exists` | Detection config silently dropped |

### Additional findings (astro-up-manifests repo -- separate PRs needed)

1. **ASTAP database manifests** (`astap-d20`, `astap-d50`, `astap-d80`, `astap-g05`, `astap-w08`) use `method = "file"` which maps to `PeFile` -- but these are data directories, not PE executables. Should use `method = "file_exists"`.

2. **Fallback TOML structure**: Both ASTAP and ASI Studio manifests use `[detection.fallback]` (nested table), but the `Detection` struct has flat `fallback_method`/`fallback_path` fields. Serde silently ignores unknown keys, so the `[detection.fallback]` section is dropped during manifest parsing. The compiler's `insert_detection()` then writes `NULL` for `fallback_config`.

## Test plan

- [x] `wmi_apps_detection_method_roundtrip` -- verifies wmi_apps primary + file_exists fallback survives catalog read
- [x] `file_exists_detection_method_roundtrip` -- verifies file_exists with path template survives catalog read
- [x] All existing detection tests pass (catalog_detection_roundtrip, detect_chain, detect_pe)
- [x] clippy clean, fmt clean
- [ ] Verify on Windows with real ASI Studio install after manifests repo fixes

## Spec Context

Follow-up from #935 (WmiApps detection method). The method was added to the detection chain but the catalog reader was not updated to parse it.
