### PR TITLE
feat: persist scan results to DB, add scan interval config

### DIFF
--- a/crates/astro-up-core/src/adapters.rs
+++ b/crates/astro-up-core/src/adapters.rs
@@ -6,8 +6,8 @@
 use std::path::PathBuf;
 
 use crate::catalog::SqliteCatalogReader;
-use crate::detect::DetectionError;
 use crate::detect::scanner::{LedgerStore, PackageSource};
+use crate::detect::{DetectionError, DetectionResult, PackageDetection};
 use crate::ledger::{LedgerEntry, LedgerSource};
 use crate::types::{Software, Version};
 
@@ -129,5 +129,172 @@ impl LedgerStore for SqliteLedgerStore {
         )
         .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
         Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Detection result persistence
+// ---------------------------------------------------------------------------
+
+/// Persists detection scan results to the app database so they survive restarts.
+pub struct DetectionStore {
+    db_path: PathBuf,
+}
+
+impl DetectionStore {
+    pub fn new(db_path: PathBuf) -> Self {
+        Self { db_path }
+    }
+
+    fn open_conn(&self) -> Result<rusqlite::Connection, DetectionError> {
+        let conn = rusqlite::Connection::open(&self.db_path)
+            .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
+        conn.execute_batch(
+            "CREATE TABLE IF NOT EXISTS detection_cache (
+                package_id TEXT PRIMARY KEY,
+                status TEXT NOT NULL,
+                version TEXT,
+                method TEXT,
+                install_path TEXT,
+                reason TEXT,
+                scanned_at TEXT NOT NULL DEFAULT (datetime('now'))
+            );
+            CREATE TABLE IF NOT EXISTS scan_metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            );",
+        )
+        .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
+        Ok(conn)
+    }
+
+    /// Persist scan results, replacing any previous cache.
+    pub fn save_results(&self, results: &[PackageDetection]) -> Result<(), DetectionError> {
+        let conn = self.open_conn()?;
+
+        conn.execute("DELETE FROM detection_cache", [])
+            .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
+
+        let mut stmt = conn
+            .prepare(
+                "INSERT INTO detection_cache (package_id, status, version, method, install_path, reason)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )
+            .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
+
+        for pd in results {
+            let (status, version, method, install_path, reason) = match &pd.result {
+                DetectionResult::Installed {
+                    version,
+                    method,
+                    install_path,
+                } => (
+                    "installed",
+                    Some(version.to_string()),
+                    Some(method.to_string()),
+                    install_path.clone(),
+                    None,
+                ),
+                DetectionResult::InstalledUnknownVersion {
+                    method,
+                    install_path,
+                } => (
+                    "installed_unknown_version",
+                    None,
+                    Some(method.to_string()),
+                    install_path.clone(),
+                    None,
+                ),
+                DetectionResult::NotInstalled => ("not_installed", None, None, None, None),
+                DetectionResult::Unavailable { reason } => {
+                    ("unavailable", None, None, None, Some(reason.clone()))
+                }
+            };
+
+            stmt.execute(rusqlite::params![
+                pd.package_id,
+                status,
+                version,
+                method,
+                install_path,
+                reason,
+            ])
+            .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
+        }
+
+        // Update last scan timestamp
+        conn.execute(
+            "INSERT INTO scan_metadata (key, value) VALUES ('last_scan_at', datetime('now'))
+             ON CONFLICT(key) DO UPDATE SET value = datetime('now')",
+            [],
+        )
+        .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    /// Load cached detection results.
+    pub fn load_results(&self) -> Result<Vec<PackageDetection>, DetectionError> {
+        let conn = self.open_conn()?;
+        let mut stmt = conn
+            .prepare(
+                "SELECT package_id, status, version, method, install_path, reason
+                 FROM detection_cache",
+            )
+            .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
+
+        let results = stmt
+            .query_map([], |row| {
+                let package_id: String = row.get(0)?;
+                let status: String = row.get(1)?;
+                let version: Option<String> = row.get(2)?;
+                let method: Option<String> = row.get(3)?;
+                let install_path: Option<String> = row.get(4)?;
+                let reason: Option<String> = row.get(5)?;
+
+                let result = match status.as_str() {
+                    "installed" => DetectionResult::Installed {
+                        version: Version::parse(&version.unwrap_or_else(|| "0.0.0".into())),
+                        method: method
+                            .as_deref()
+                            .unwrap_or("registry")
+                            .parse()
+                            .unwrap_or(crate::types::DetectionMethod::Registry),
+                        install_path,
+                    },
+                    "installed_unknown_version" => DetectionResult::InstalledUnknownVersion {
+                        method: method
+                            .as_deref()
+                            .unwrap_or("registry")
+                            .parse()
+                            .unwrap_or(crate::types::DetectionMethod::Registry),
+                        install_path,
+                    },
+                    "unavailable" => DetectionResult::Unavailable {
+                        reason: reason.unwrap_or_default(),
+                    },
+                    _ => DetectionResult::NotInstalled,
+                };
+
+                Ok(PackageDetection { package_id, result })
+            })
+            .map_err(|e| DetectionError::LedgerError(e.to_string()))?
+            .collect::<Result<Vec<_>, _>>()
+            .map_err(|e| DetectionError::LedgerError(e.to_string()))?;
+
+        Ok(results)
+    }
+
+    /// Get the timestamp of the last scan, or `None` if never scanned.
+    pub fn last_scan_at(&self) -> Result<Option<String>, DetectionError> {
+        let conn = self.open_conn()?;
+        let result: Option<String> = conn
+            .query_row(
+                "SELECT value FROM scan_metadata WHERE key = 'last_scan_at'",
+                [],
+                |row| row.get(0),
+            )
+            .ok();
+        Ok(result)
     }
 }

--- a/crates/astro-up-core/src/config/defaults.rs
+++ b/crates/astro-up-core/src/config/defaults.rs
@@ -3,8 +3,8 @@ use std::time::Duration;
 
 use super::model::{
     BackupPolicyConfig, BackupSchedule, CatalogConfig, FontSize, InstallMethod, InstallScope,
-    LogConfig, LogLevel, NetworkConfig, NotificationsConfig, PathsConfig, ThemeMode, UiConfig,
-    UpdateConfig,
+    LogConfig, LogLevel, NetworkConfig, NotificationsConfig, PathsConfig, ScanInterval, ThemeMode,
+    UiConfig, UpdateConfig,
 };
 
 impl Default for UiConfig {
@@ -13,6 +13,7 @@ impl Default for UiConfig {
             theme: ThemeMode::default(),
             font_size: FontSize::default(),
             auto_scan_on_launch: false,
+            scan_interval: ScanInterval::default(),
             default_install_scope: InstallScope::default(),
             default_install_method: InstallMethod::default(),
             auto_check_updates: true,

--- a/crates/astro-up-core/src/config/mod.rs
+++ b/crates/astro-up-core/src/config/mod.rs
@@ -16,7 +16,7 @@ pub use api::{config_get, config_list, config_reset, config_set};
 pub use model::{
     AppConfig, BackupPolicyConfig, BackupSchedule, CatalogConfig, FontSize, InstallMethod,
     InstallScope, LogConfig, LogLevel, NetworkConfig, NotificationsConfig, PathsConfig,
-    StartupConfig, TelemetryConfig, ThemeMode, UiConfig, UpdateConfig,
+    ScanInterval, StartupConfig, TelemetryConfig, ThemeMode, UiConfig, UpdateConfig,
 };
 pub use store::ConfigStore;
 
@@ -126,6 +126,10 @@ pub(crate) fn set_field(config: &mut AppConfig, key: &str, value: &str) -> Resul
             config.ui.auto_scan_on_launch = value
                 .parse::<bool>()
                 .map_err(|_| parse_err("boolean (true/false)"))?;
+        }
+        "ui.scan_interval" => {
+            config.ui.scan_interval = model::ScanInterval::from_str(value)
+                .map_err(|_| parse_err("scan interval (manual/on_startup/hourly/daily/weekly)"))?;
         }
         "ui.default_install_scope" => {
             config.ui.default_install_scope = model::InstallScope::from_str(value)
@@ -316,6 +320,7 @@ pub(crate) fn get_field_value(config: &AppConfig, key: &str) -> Option<String> {
         "ui.theme" => Some(config.ui.theme.to_string()),
         "ui.font_size" => Some(config.ui.font_size.to_string()),
         "ui.auto_scan_on_launch" => Some(config.ui.auto_scan_on_launch.to_string()),
+        "ui.scan_interval" => Some(config.ui.scan_interval.to_string()),
         "ui.default_install_scope" => Some(config.ui.default_install_scope.to_string()),
         "ui.default_install_method" => Some(config.ui.default_install_method.to_string()),
         "ui.auto_check_updates" => Some(config.ui.auto_check_updates.to_string()),

--- a/crates/astro-up-core/src/config/model.rs
+++ b/crates/astro-up-core/src/config/model.rs
@@ -47,6 +47,24 @@ pub enum InstallMethod {
     Interactive,
 }
 
+/// How often to automatically scan for installed software.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Display, EnumString)]
+#[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
+pub enum ScanInterval {
+    /// Never auto-scan — only when the user clicks "Scan"
+    Manual,
+    /// Scan once when the app starts (if stale)
+    #[default]
+    OnStartup,
+    /// Scan every hour
+    Hourly,
+    /// Scan once per day
+    Daily,
+    /// Scan once per week
+    Weekly,
+}
+
 /// Backup schedule frequency.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Display, EnumString)]
 #[serde(rename_all = "lowercase")]
@@ -103,6 +121,7 @@ pub struct UiConfig {
     pub theme: ThemeMode,
     pub font_size: FontSize,
     pub auto_scan_on_launch: bool,
+    pub scan_interval: ScanInterval,
     pub default_install_scope: InstallScope,
     pub default_install_method: InstallMethod,
     pub auto_check_updates: bool,

--- a/crates/astro-up-core/tests/config/defaults_test.rs
+++ b/crates/astro-up-core/tests/config/defaults_test.rs
@@ -80,5 +80,5 @@ fn known_keys_discovers_all_fields() {
     assert!(keys.contains(&"network.timeout".to_string()));
     assert!(keys.contains(&"logging.level".to_string()));
     assert!(keys.contains(&"telemetry.enabled".to_string()));
-    assert_eq!(keys.len(), 42);
+    assert_eq!(keys.len(), 43);
 }

--- a/crates/astro-up-core/tests/config/edge_cases_test.rs
+++ b/crates/astro-up-core/tests/config/edge_cases_test.rs
@@ -65,7 +65,7 @@ fn config_list_empty_db_returns_all_defaults() {
     let config = load_config(&db_path, paths, log_file, &[]).unwrap();
 
     let list = config_list(&config, &[]);
-    assert_eq!(list.len(), 42);
+    assert_eq!(list.len(), 43);
     assert!(list.iter().all(|(_, _, overridden)| !overridden));
 }
 

--- a/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
+++ b/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
@@ -59,6 +59,7 @@ expression: value
     "default_install_method": "interactive",
     "default_install_scope": "user",
     "font_size": "medium",
+    "scan_interval": "on_startup",
     "theme": "system"
   },
   "updates": {

--- a/crates/astro-up-gui/src/commands.rs
+++ b/crates/astro-up-gui/src/commands.rs
@@ -11,7 +11,7 @@ use astro_up_core::detect::scanner::Scanner;
 use astro_up_core::events::Event;
 
 use crate::state::{AppState, OperationId};
-use astro_up_core::adapters::{CatalogPackageSource, SqliteLedgerStore};
+use astro_up_core::adapters::{CatalogPackageSource, DetectionStore, SqliteLedgerStore};
 
 /// Payload emitted to the frontend when the orchestrator needs asset selection.
 #[derive(Debug, Clone, Serialize)]
@@ -190,6 +190,15 @@ fn try_list_software(
         .map(|e| (e.package_id.clone(), e.version.to_string()))
         .collect();
 
+    // Load persisted detection results
+    let detection_store = DetectionStore::new(state.db_path.clone());
+    let detection_results = detection_store.load_results().unwrap_or_default();
+    let detection_map: std::collections::HashMap<String, astro_up_core::detect::DetectionResult> =
+        detection_results
+            .into_iter()
+            .map(|pd| (pd.package_id, pd.result))
+            .collect();
+
     let packages = match filter {
         "installed" => {
             if acknowledged.is_empty() {
@@ -248,6 +257,14 @@ fn try_list_software(
                 "update_available".into(),
                 serde_json::json!(update_available),
             );
+
+            // Include cached detection result if available
+            if let Some(detection) = detection_map.get(&pkg_id) {
+                obj.insert(
+                    "detection".into(),
+                    serde_json::to_value(detection).unwrap_or_default(),
+                );
+            }
 
             val
         })
@@ -458,6 +475,12 @@ pub async fn scan_installed(
         code: "scan_error".into(),
     })?;
 
+    // Persist detection results to DB
+    let detection_store = DetectionStore::new(state.db_path.clone());
+    if let Err(e) = detection_store.save_results(&scan_result.results) {
+        tracing::warn!(error = %e, "failed to persist detection results");
+    }
+
     let total_found = scan_result
         .results
         .iter()
@@ -508,6 +531,15 @@ pub async fn get_activity(
         .map_err(|e| CoreError::from(e.to_string()))?;
 
     serde_json::to_value(&records).map_err(|e| CoreError::from(e.to_string()))
+}
+
+#[tauri::command]
+pub async fn get_last_scan(state: State<'_, AppState>) -> Result<serde_json::Value, CoreError> {
+    let detection_store = DetectionStore::new(state.db_path.clone());
+    let last_scan = detection_store
+        .last_scan_at()
+        .map_err(|e| CoreError::from(e.to_string()))?;
+    Ok(serde_json::json!({ "last_scan_at": last_scan }))
 }
 
 /// Shared helper: create an orchestrator, plan, and execute.

--- a/crates/astro-up-gui/src/lib.rs
+++ b/crates/astro-up-gui/src/lib.rs
@@ -238,6 +238,7 @@ pub fn run() {
             commands::clear_directory,
             commands::resolve_asset_selection,
             commands::get_activity,
+            commands::get_last_scan,
         ])
         .setup(|app| {
             let start = std::time::Instant::now();

--- a/frontend/src/components/settings/GeneralSection.vue
+++ b/frontend/src/components/settings/GeneralSection.vue
@@ -21,6 +21,14 @@ const methodOptions = [
   { label: "Interactive", value: "interactive" },
 ];
 
+const scanIntervalOptions = [
+  { label: "Manual only", value: "manual" },
+  { label: "On startup", value: "on_startup" },
+  { label: "Every hour", value: "hourly" },
+  { label: "Daily", value: "daily" },
+  { label: "Weekly", value: "weekly" },
+];
+
 // Values must match humantime_serde output format
 const intervalOptions = [
   { label: "1 hour", value: "1h" },
@@ -46,6 +54,15 @@ const intervalOptions = [
     <div class="field-toggle">
       <ToggleSwitch v-model="config.auto_scan_on_launch" />
       <label>Auto-scan on launch</label>
+    </div>
+    <div class="field">
+      <label>Scan Interval</label>
+      <Select
+        v-model="config.scan_interval"
+        :options="scanIntervalOptions"
+        option-label="label"
+        option-value="value"
+      />
     </div>
     <div class="field">
       <label>Default Install Scope</label>

--- a/frontend/src/composables/useInvoke.ts
+++ b/frontend/src/composables/useInvoke.ts
@@ -179,8 +179,16 @@ export function useScanInstalled() {
     mutationFn: () => { logMutation("scan_installed"); return invoke<unknown>("scan_installed"); },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ["software"] });
+      queryClient.invalidateQueries({ queryKey: ["last-scan"] });
     },
     onError,
+  });
+}
+
+export function useLastScan() {
+  return useQuery({
+    queryKey: ["last-scan"],
+    queryFn: () => invoke<{ last_scan_at: string | null }>("get_last_scan"),
   });
 }
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -11,10 +11,13 @@ export interface AppConfig {
   telemetry: TelemetryConfig;
 }
 
+export type ScanInterval = "manual" | "on_startup" | "hourly" | "daily" | "weekly";
+
 export interface UiConfig {
   theme: "dark" | "light" | "system";
   font_size: "small" | "medium" | "large";
   auto_scan_on_launch: boolean;
+  scan_interval: ScanInterval;
   default_install_scope: "user" | "machine";
   default_install_method: "silent" | "interactive";
   auto_check_updates: boolean;

--- a/frontend/src/validation/config.ts
+++ b/frontend/src/validation/config.ts
@@ -4,6 +4,7 @@ export const UiSchema = v.object({
   theme: v.picklist(["dark", "light", "system"]),
   font_size: v.picklist(["small", "medium", "large"]),
   auto_scan_on_launch: v.boolean(),
+  scan_interval: v.picklist(["manual", "on_startup", "hourly", "daily", "weekly"]),
   default_install_scope: v.picklist(["user", "machine"]),
   default_install_method: v.picklist(["silent", "interactive"]),
   auto_check_updates: v.boolean(),

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -40,6 +40,7 @@ const sections = [
 const defaultConfig: AppConfig = {
   ui: {
     theme: "system", font_size: "medium", auto_scan_on_launch: true,
+    scan_interval: "on_startup",
     default_install_scope: "user", default_install_method: "silent",
     auto_check_updates: true, check_interval: "1day",
     auto_notify_updates: true, auto_install_updates: false,


### PR DESCRIPTION
## Summary

Detection results now persist across app restarts instead of being ephemeral:
- New `detection_cache` SQLite table stores scan results per package (status, version, method, install_path)
- New `scan_metadata` table stores `last_scan_at` timestamp
- `list_software` enriches packages with cached detection results, fixing "Not scanned" in the Detection section
- New `get_last_scan` Tauri command for the frontend to query last scan time
- New `scan_interval` config setting (manual/on_startup/hourly/daily/weekly) alongside existing `auto_scan_on_launch`
- Frontend: scan interval dropdown in General Settings, `useLastScan` query hook

## What's new

| Area | Change |
|------|--------|
| Backend | `DetectionStore` in `adapters.rs` — save/load detection results, last_scan_at |
| Backend | `ScanInterval` enum in config model |
| Backend | `scan_installed` now persists results after scanning |
| Backend | `list_software` includes detection data from cache |
| Frontend | Scan Interval dropdown in Settings > General |
| Frontend | `useLastScan()` query + cache invalidation on scan |

## Test plan

- [ ] Run scan, close app, reopen — detection status persists (Detail > Overview/Technical tabs show detection method)
- [ ] Settings > General shows Scan Interval dropdown with 5 options
- [ ] `get_last_scan` returns correct timestamp after scan
- [ ] Config snapshot includes `scan_interval` field
