### PR TITLE
fix: record installation to ledger after successful install

### DIFF
--- a/crates/astro-up-core/src/engine/orchestrator.rs
+++ b/crates/astro-up-core/src/engine/orchestrator.rs
@@ -607,6 +607,24 @@ where
             install_status
         };
 
+        // 7b. Record to ledger on success so package shows as installed
+        if matches!(
+            final_status,
+            super::history::OperationStatus::Success
+                | super::history::OperationStatus::RebootPending
+        ) {
+            if let Err(e) = self
+                .detector
+                .upsert_acknowledged(pkg_id.as_ref(), &planned.target_version)
+            {
+                tracing::warn!(
+                    package = %pkg_id,
+                    error = %e,
+                    "failed to record installation to ledger"
+                );
+            }
+        }
+
         // 8. Emit PackageComplete
         let status_str = match &final_status {
             super::history::OperationStatus::Success => "succeeded",


### PR DESCRIPTION
## Summary

- Record installed package to the ledger after successful install/update
- Previously the orchestrator only wrote to the operations history table, so packages installed via astro-up wouldn't appear as "installed" until the next scan

## Test plan

- [ ] Install a package via astro-up, verify it appears in the Installed view without needing a scan
- [ ] Update a package, verify the new version shows in the Installed view
