### PR TITLE
fix: stale operation blocking, missing backup data, UI cleanup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.16"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.15"
+version = "0.1.16"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/crates/astro-up-core/src/catalog/reader.rs
+++ b/crates/astro-up-core/src/catalog/reader.rs
@@ -319,7 +319,7 @@ impl SqliteCatalogReader {
                     Ok((
                         row.get::<_, String>(0)?,
                         row.get::<_, Option<String>>(1)?,
-                        row.get::<_, i32>(2)?,
+                        row.get::<_, Option<String>>(2)?,
                         row.get::<_, Option<String>>(3)?,
                         row.get::<_, Option<String>>(4)?,
                         row.get::<_, Option<String>>(5)?,
@@ -332,7 +332,7 @@ impl SqliteCatalogReader {
         let Some((
             method_str,
             scope_str,
-            elevation_int,
+            elevation_str,
             switches_json,
             exit_codes_json,
             success_codes_json,
@@ -361,11 +361,12 @@ impl SqliteCatalogReader {
             )
             .unwrap_or(None);
         let scope = scope_str.and_then(|s| s.parse().ok());
-        let elevation = if elevation_int != 0 {
-            Some(crate::types::Elevation::Required)
-        } else {
-            None
-        };
+        let elevation = elevation_str.and_then(|s| match s.as_str() {
+            "required" => Some(crate::types::Elevation::Required),
+            "prohibited" => Some(crate::types::Elevation::Prohibited),
+            "self" => Some(crate::types::Elevation::Self_),
+            _ => None,
+        });
 
         let switches = switches_json
             .and_then(|json| {

--- a/crates/astro-up-core/src/config/model.rs
+++ b/crates/astro-up-core/src/config/model.rs
@@ -55,9 +55,9 @@ pub enum ScanInterval {
     /// Never auto-scan — only when the user clicks "Scan"
     Manual,
     /// Scan once when the app starts (if stale)
-    #[default]
     OnStartup,
     /// Scan every hour
+    #[default]
     Hourly,
     /// Scan once per day
     Daily,

--- a/crates/astro-up-core/tests/catalog_detection_roundtrip.rs
+++ b/crates/astro-up-core/tests/catalog_detection_roundtrip.rs
@@ -60,7 +60,7 @@ fn create_test_catalog(dir: &std::path::Path) -> std::path::PathBuf {
             package_id TEXT PRIMARY KEY REFERENCES packages(id),
             method TEXT NOT NULL,
             scope TEXT,
-            elevation INTEGER NOT NULL DEFAULT 0,
+            elevation TEXT,
             switches TEXT,
             exit_codes TEXT,
             success_codes TEXT
@@ -157,7 +157,7 @@ fn create_test_catalog(dir: &std::path::Path) -> std::path::PathBuf {
         params![
             "nina",
             "inno_setup",
-            0,
+            Option::<String>::None,
             r#"{"silent":"/VERYSILENT /NORESTART /SUPPRESSMSGBOXES"}"#,
         ],
     )

--- a/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
+++ b/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/astro-up-core/tests/config/defaults_test.rs
-assertion_line: 53
 expression: value
 ---
 {
@@ -60,7 +59,7 @@ expression: value
     "default_install_method": "interactive",
     "default_install_scope": "user",
     "font_size": "medium",
-    "scan_interval": "on_startup",
+    "scan_interval": "hourly",
     "survey_completed_at": null,
     "survey_dismissed_at": null,
     "survey_threshold": 3,

--- a/crates/astro-up-gui/src/commands.rs
+++ b/crates/astro-up-gui/src/commands.rs
@@ -273,6 +273,13 @@ fn try_list_software(
                 }
             }
 
+            // Include backup config (config_paths for backup-eligible packages)
+            if let Ok(Some(backup)) = reader.backup_config(&pkg.id) {
+                if let Ok(backup_val) = serde_json::to_value(&backup) {
+                    obj.insert("backup".into(), backup_val);
+                }
+            }
+
             val
         })
         .collect();

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -164,6 +164,14 @@ useCoreEvents((event: CoreEvent) => {
   } else if (event.type === "orchestration_complete") {
     if (!queueActive.value) {
       addStep("info", `Done: ${event.data.succeeded} succeeded, ${event.data.failed} failed`);
+      // Safety: ensure operation is marked complete even if package_complete was missed
+      if (isRunning.value) {
+        if (event.data.failed > 0) {
+          failOperation(`${event.data.failed} package(s) failed`);
+        } else {
+          completeOperation();
+        }
+      }
     }
   }
 

--- a/frontend/src/components/settings/GeneralSection.vue
+++ b/frontend/src/components/settings/GeneralSection.vue
@@ -102,10 +102,6 @@ const intervalOptions = [
       <ToggleSwitch v-model="config.auto_notify_updates" />
       <label>Notify on updates</label>
     </div>
-    <div class="field-toggle">
-      <ToggleSwitch v-model="config.auto_install_updates" />
-      <label>Auto-install updates</label>
-    </div>
   </div>
 </template>
 

--- a/frontend/src/composables/useOperations.ts
+++ b/frontend/src/composables/useOperations.ts
@@ -15,10 +15,11 @@ export function useOperations() {
       activeOperation.value = null;
     }
 
-    // Safety valve: force-clear stale running operations (>60s)
+    // Safety valve: force-clear stale running operations (>10min)
     if (activeOperation.value && activeOperation.value.status === "running") {
       const started = activeOperation.value.steps[0]?.timestamp;
-      if (started && Date.now() - new Date(started).getTime() > 60_000) {
+      if (started && Date.now() - new Date(started).getTime() > 600_000) {
+        logger.debug("useOperations", `force-clearing stale operation: ${activeOperation.value.id}`);
         activeOperation.value = null;
       }
     }


### PR DESCRIPTION
## Summary

- Stale operation timeout increased from 60s to 10min (large downloads were getting blocked)
- `orchestration_complete` event now force-completes stuck operations as safety net
- `list_software` includes backup config from catalog (fixes missing Backup Now button on hero and dashboard)
- Remove non-functional "Auto-install updates" toggle from Settings
- Default scan interval changed from `on_startup` to `hourly`

## Test plan

- [ ] Install/update a package, then try another — no "operation already in progress" message
- [ ] Packages with backup config show "Backup Now" button in detail hero
- [ ] Settings > General no longer shows "Auto-install updates"
- [ ] Fresh install defaults to hourly scan interval
