### PR TITLE
fix: use correct tauri-action input for updater JSON upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,7 @@ jobs:
           releaseBody: ${{ needs.release-please.outputs.release_notes }}
           releaseDraft: true
           prerelease: false
-          includeUpdaterJson: true
+          uploadUpdaterJson: true
           updaterJsonPreferNsis: true
 
   publish-release:


### PR DESCRIPTION
## Summary

The tauri-action input was named `includeUpdaterJson` (silently ignored) instead of the correct `uploadUpdaterJson`. This caused `latest.json` to never be uploaded to GitHub Releases, breaking the in-app self-update check.

## Root cause

`includeUpdaterJson` is not a valid input for `tauri-apps/tauri-action@v0`. The correct input name is `uploadUpdaterJson` per the [action docs](https://github.com/tauri-apps/tauri-action). Invalid inputs are silently ignored by GitHub Actions.

## Test plan

- [ ] After merge + release: verify `latest.json` appears as a release asset
- [ ] App self-update check no longer shows "endpoint did not respond with a successful status code"
