### PR TITLE
fix: pin tauri-action to action-v0.6.2 for updater JSON upload

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
         run: cargo install tauri-cli --version ^2 --locked
 
       - name: Build Tauri app
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@action-v0.6.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -111,7 +111,7 @@ jobs:
           releaseBody: ${{ needs.release-please.outputs.release_notes }}
           releaseDraft: true
           prerelease: false
-          uploadUpdaterJson: true
+          includeUpdaterJson: true
           updaterJsonPreferNsis: true
 
   publish-release:


### PR DESCRIPTION
## Summary

Upgrade `tauri-apps/tauri-action` from `@v0` to `@v1` to fix the updater JSON upload.

`@v0` has a bug where it generates NSIS `.sig` files correctly but fails to find them when constructing `latest.json`, logging "Signature not found for the updater JSON. Skipping upload..." — this has been broken for every release so far.

`@v1` uses `uploadUpdaterJson` input (vs `@v0`'s `includeUpdaterJson`) and fixes the signature file matching.

## Test plan

- [ ] After release: verify `latest.json` appears as a release asset on GitHub
- [ ] Verify `latest.json` contains correct version, signature, and download URL
- [ ] App self-update check succeeds
