### PR TITLE
fix: rotate updater signing key pair

### DIFF
--- a/crates/astro-up-gui/tauri.conf.json
+++ b/crates/astro-up-gui/tauri.conf.json
@@ -40,7 +40,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDExMEM2RDA1M0I2RTc0RkQKUldUOWRHNDdCVzBNRWFLZGUxTUZFL1NxdzIrVEJCamlQN1hKYUtQWDdEWndZWFo2dk0xSkt3bmQK",
+      "pubkey": "W50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcwRkMwN0U3OURGODJBOUYKUldTZkt2aWQ1d2Y4Y09WeFJac0tBRGdWWHg3UVQ3djYveFQ1UVF1TTNWNkVrTUo0QUJQNWhmYUMK",
       "endpoints": [
         "https://github.com/nightwatch-astro/astro-up/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary

Regenerated Tauri updater signing key pair. The previous `TAURI_SIGNING_PRIVATE_KEY` had a malformed base64 character at offset 141, causing `cargo tauri build` to fail when `createUpdaterArtifacts: true` was enabled.

**Breaking**: Existing installations cannot auto-update to this version due to key rotation. Users must download the new installer manually.

## Test plan

- [ ] Release build succeeds (no base64 decode error)
- [ ] `latest.json` appears as a release asset
- [ ] Fresh install can auto-update to subsequent releases
