### PR TITLE
fix: correct updater public key after regeneration

### DIFF
--- a/crates/astro-up-gui/tauri.conf.json
+++ b/crates/astro-up-gui/tauri.conf.json
@@ -40,7 +40,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "W50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDcwRkMwN0U3OURGODJBOUYKUldTZkt2aWQ1d2Y4Y09WeFJac0tBRGdWWHg3UVQ3djYveFQ1UVF1TTNWNkVrTUo0QUJQNWhmYUMK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IDVBNUVEODY0MUUyNEUwRDQKUldUVTRDUWVaTmhlV29JTGhOcFZiT3FjQTVJcFhsbTZUNzFRc1hhZm9DNmRWeHVsd2xvV1lNa2wK",
       "endpoints": [
         "https://github.com/nightwatch-astro/astro-up/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
## Summary

Fix the updater public key — previous commit had a truncated key (missing leading `d` in base64). Regenerated key pair and updated both the GitHub secret and this pubkey.

## Test plan

- [ ] Release build succeeds
- [ ] `latest.json` appears as release asset
