### PR TITLE
fix: correct registry detection key format in discovery

### DIFF
--- a/crates/astro-up-cli/tests/cli_lifecycle_test.rs
+++ b/crates/astro-up-cli/tests/cli_lifecycle_test.rs
@@ -30,7 +30,7 @@ fn sample_report() -> LifecycleReport {
                 duration: Duration::from_millis(567),
                 exit_code: None,
                 logs: vec![
-                    r#"{"method":"registry","registry_key":"NINA 2","registry_value":"DisplayVersion"}"#
+                    r#"{"method":"registry","registry_key":"HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NINA 2_is1","registry_value":"DisplayVersion"}"#
                         .into(),
                 ],
                 warnings: vec![],
@@ -38,7 +38,7 @@ fn sample_report() -> LifecycleReport {
         ],
         discovered_config: Some(DetectionConfig {
             method: DetectionMethod::Registry,
-            registry_key: Some("NINA 2".into()),
+            registry_key: Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1".into()),
             registry_value: Some("DisplayVersion".into()),
             file_path: None,
             version_regex: None,
@@ -65,7 +65,7 @@ fn snapshot_lifecycle_report_json() {
 fn snapshot_lifecycle_report_toml_config() {
     let config = DetectionConfig {
         method: DetectionMethod::Registry,
-        registry_key: Some("NINA 2".into()),
+        registry_key: Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1".into()),
         registry_value: Some("DisplayVersion".into()),
         file_path: None,
         version_regex: None,

--- a/crates/astro-up-cli/tests/cli_lifecycle_test.rs
+++ b/crates/astro-up-cli/tests/cli_lifecycle_test.rs
@@ -65,7 +65,10 @@ fn snapshot_lifecycle_report_json() {
 fn snapshot_lifecycle_report_toml_config() {
     let config = DetectionConfig {
         method: DetectionMethod::Registry,
-        registry_key: Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1".into()),
+        registry_key: Some(
+            r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1"
+                .into(),
+        ),
         registry_value: Some("DisplayVersion".into()),
         file_path: None,
         version_regex: None,

--- a/crates/astro-up-cli/tests/snapshots/cli_lifecycle_test__lifecycle_detection_toml.snap
+++ b/crates/astro-up-cli/tests/snapshots/cli_lifecycle_test__lifecycle_detection_toml.snap
@@ -4,7 +4,7 @@ expression: toml
 ---
 [detection]
 method = "registry"
-registry_key = "NINA 2"
+registry_key = 'HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1'
 registry_value = "DisplayVersion"
 
 [fallback]

--- a/crates/astro-up-cli/tests/snapshots/cli_lifecycle_test__lifecycle_report_json.snap
+++ b/crates/astro-up-cli/tests/snapshots/cli_lifecycle_test__lifecycle_report_json.snap
@@ -20,14 +20,14 @@ expression: json
       "status": "pass",
       "duration": 567,
       "logs": [
-        "{\"method\":\"registry\",\"registry_key\":\"NINA 2\",\"registry_value\":\"DisplayVersion\"}"
+        "{\"method\":\"registry\",\"registry_key\":\"HKEY_LOCAL_MACHINE\\\\SOFTWARE\\\\Microsoft\\\\Windows\\\\CurrentVersion\\\\Uninstall\\\\NINA 2_is1\",\"registry_value\":\"DisplayVersion\"}"
       ],
       "warnings": []
     }
   ],
   "discovered_config": {
     "method": "registry",
-    "registry_key": "NINA 2",
+    "registry_key": "HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NINA 2_is1",
     "registry_value": "DisplayVersion",
     "file_path": null,
     "version_regex": null,

--- a/crates/astro-up-core/src/detect/discovery.rs
+++ b/crates/astro-up-core/src/detect/discovery.rs
@@ -197,6 +197,13 @@ impl DiscoveryScanner {
                 continue;
             };
 
+            // Determine the hive prefix string for absolute registry key paths
+            let hive_prefix = if *hive == HKEY_LOCAL_MACHINE {
+                r"HKEY_LOCAL_MACHINE\"
+            } else {
+                r"HKEY_CURRENT_USER\"
+            };
+
             for subkey_name in uninstall_key.enum_keys().flatten() {
                 let Ok(subkey) = uninstall_key.open_subkey(&subkey_name) else {
                     continue;
@@ -242,14 +249,17 @@ impl DiscoveryScanner {
                     DiscoveryConfidence::Medium
                 };
 
-                let _registry_key =
-                    format!(r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}");
+                // Build absolute registry key path (e.g., HKEY_LOCAL_MACHINE\SOFTWARE\...\NINA 2_is1)
+                // registry::detect() requires this prefix to select the correct hive.
+                let absolute_key = format!(
+                    r"{hive_prefix}SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{subkey_name}"
+                );
 
                 candidates.push(DiscoveryCandidate {
                     method: DetectionMethod::Registry,
                     config: DetectionConfig {
                         method: DetectionMethod::Registry,
-                        registry_key: Some(subkey_name.clone()),
+                        registry_key: Some(absolute_key),
                         registry_value: Some("DisplayVersion".into()),
                         file_path: None,
                         version_regex: None,

--- a/crates/astro-up-core/src/detect/mod.rs
+++ b/crates/astro-up-core/src/detect/mod.rs
@@ -117,12 +117,56 @@ pub async fn run_chain(
     let result = run_single_method(config, resolver, ledger_path, wmi_ctx).await;
 
     match &result {
-        DetectionResult::Installed { .. } | DetectionResult::InstalledUnknownVersion { .. } => {
+        DetectionResult::Installed { version, method, .. } => {
+            tracing::debug!(
+                method = %method,
+                version = %version,
+                "detection chain: installed"
+            );
             result
         }
-        _ => match &config.fallback {
-            Some(next) => Box::pin(run_chain(next, resolver, ledger_path, wmi_ctx)).await,
-            None => result,
+        DetectionResult::InstalledUnknownVersion { method, .. } => {
+            tracing::debug!(
+                method = %method,
+                "detection chain: installed (unknown version)"
+            );
+            result
+        }
+        DetectionResult::NotInstalled => match &config.fallback {
+            Some(next) => {
+                tracing::debug!(
+                    method = %config.method,
+                    next_method = %next.method,
+                    "detection chain: not installed, trying fallback"
+                );
+                Box::pin(run_chain(next, resolver, ledger_path, wmi_ctx)).await
+            }
+            None => {
+                tracing::debug!(
+                    method = %config.method,
+                    "detection chain: not installed, no fallback"
+                );
+                result
+            }
+        },
+        DetectionResult::Unavailable { reason } => match &config.fallback {
+            Some(next) => {
+                tracing::debug!(
+                    method = %config.method,
+                    reason = %reason,
+                    next_method = %next.method,
+                    "detection chain: unavailable, trying fallback"
+                );
+                Box::pin(run_chain(next, resolver, ledger_path, wmi_ctx)).await
+            }
+            None => {
+                tracing::debug!(
+                    method = %config.method,
+                    reason = %reason,
+                    "detection chain: unavailable, no fallback"
+                );
+                result
+            }
         },
     }
 }

--- a/crates/astro-up-core/src/detect/mod.rs
+++ b/crates/astro-up-core/src/detect/mod.rs
@@ -117,7 +117,9 @@ pub async fn run_chain(
     let result = run_single_method(config, resolver, ledger_path, wmi_ctx).await;
 
     match &result {
-        DetectionResult::Installed { version, method, .. } => {
+        DetectionResult::Installed {
+            version, method, ..
+        } => {
             tracing::debug!(
                 method = %method,
                 version = %version,

--- a/crates/astro-up-core/src/detect/registry.rs
+++ b/crates/astro-up-core/src/detect/registry.rs
@@ -91,9 +91,7 @@ fn detect_windows(config: &DetectionConfig) -> DetectionResult {
                 key = %key_path,
                 "bare subkey name detected, auto-prefixing with Uninstall path"
             );
-            let subkey = format!(
-                r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{key_path}"
-            );
+            let subkey = format!(r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{key_path}");
             (
                 vec![
                     (HKEY_LOCAL_MACHINE, KEY_READ | KEY_WOW64_64KEY),

--- a/crates/astro-up-core/src/detect/registry.rs
+++ b/crates/astro-up-core/src/detect/registry.rs
@@ -7,9 +7,13 @@ use crate::types::{DetectionMethod, Version};
 
 /// Detect installed software via Windows registry keys.
 ///
-/// `registry_key` must be an absolute path starting with `HKEY_LOCAL_MACHINE\`
+/// `registry_key` should be an absolute path starting with `HKEY_LOCAL_MACHINE\`
 /// or `HKEY_CURRENT_USER\`. `WOW6432Node` segments are stripped — the WOW64
 /// registry flags handle 32/64-bit redirection transparently.
+///
+/// For backward compatibility, bare Uninstall subkey names (e.g., `"NINA 2_is1"`)
+/// are auto-prefixed with the standard Uninstall path and searched in both
+/// HKLM and HKCU hives.
 ///
 /// Reads the value named in `config.registry_value` (default: `DisplayVersion`).
 #[tracing::instrument(skip_all)]
@@ -21,21 +25,30 @@ pub async fn detect(config: &DetectionConfig) -> DetectionResult {
     }
     #[cfg(not(windows))]
     {
-        // Validate path format even on non-Windows so catalog issues surface early.
         if let Some(ref key) = config.registry_key {
-            if !key.starts_with(r"HKEY_LOCAL_MACHINE\") && !key.starts_with(r"HKEY_CURRENT_USER\") {
-                return DetectionResult::Unavailable {
-                    reason: format!(
-                        "registry_key must be an absolute path starting with \
-                         HKEY_LOCAL_MACHINE\\ or HKEY_CURRENT_USER\\, got: {key}"
-                    ),
-                };
+            // Accept both absolute paths and bare subkey names on non-Windows
+            // (returns Unavailable regardless, but validates format for diagnostics)
+            if !key.starts_with(r"HKEY_LOCAL_MACHINE\")
+                && !key.starts_with(r"HKEY_CURRENT_USER\")
+                && !is_bare_subkey_name(key)
+            {
+                tracing::warn!(
+                    method = "registry",
+                    key = %key,
+                    "registry_key is neither an absolute path nor a bare subkey name"
+                );
             }
         }
         DetectionResult::Unavailable {
             reason: "registry detection requires Windows".into(),
         }
     }
+}
+
+/// Check if a registry key string looks like a bare Uninstall subkey name
+/// (e.g., "NINA 2_is1") rather than an absolute registry path.
+fn is_bare_subkey_name(key: &str) -> bool {
+    !key.starts_with(r"HKEY_") && !key.starts_with(r"SOFTWARE\")
 }
 
 #[cfg(windows)]
@@ -54,19 +67,41 @@ fn detect_windows(config: &DetectionConfig) -> DetectionResult {
 
     // Parse absolute registry path into (hive, subkey).
     // Strip WOW6432Node — WOW64 flags handle redirection transparently.
+    //
+    // For backward compatibility, bare subkey names (e.g., "NINA 2_is1") are
+    // auto-prefixed with the standard Uninstall path and searched in all hives.
     let (hive_searches, subkey_path) =
         if let Some(rest) = key_path.strip_prefix(r"HKEY_LOCAL_MACHINE\") {
             let normalized = rest.replace(r"WOW6432Node\", "");
             (
-                &[
+                vec![
                     (HKEY_LOCAL_MACHINE, KEY_READ | KEY_WOW64_64KEY),
                     (HKEY_LOCAL_MACHINE, KEY_READ | KEY_WOW64_32KEY),
-                ][..],
+                ],
                 normalized,
             )
         } else if let Some(rest) = key_path.strip_prefix(r"HKEY_CURRENT_USER\") {
             let normalized = rest.replace(r"WOW6432Node\", "");
-            (&[(HKEY_CURRENT_USER, KEY_READ)][..], normalized)
+            (vec![(HKEY_CURRENT_USER, KEY_READ)], normalized)
+        } else if is_bare_subkey_name(key_path) {
+            // Bare subkey name — assume it's under the standard Uninstall path.
+            // Search HKLM (64-bit, 32-bit) and HKCU.
+            debug!(
+                method = "registry",
+                key = %key_path,
+                "bare subkey name detected, auto-prefixing with Uninstall path"
+            );
+            let subkey = format!(
+                r"SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\{key_path}"
+            );
+            (
+                vec![
+                    (HKEY_LOCAL_MACHINE, KEY_READ | KEY_WOW64_64KEY),
+                    (HKEY_LOCAL_MACHINE, KEY_READ | KEY_WOW64_32KEY),
+                    (HKEY_CURRENT_USER, KEY_READ),
+                ],
+                subkey,
+            )
         } else {
             return DetectionResult::Unavailable {
                 reason: format!(
@@ -76,10 +111,10 @@ fn detect_windows(config: &DetectionConfig) -> DetectionResult {
             };
         };
 
-    for &(hive, flags) in hive_searches {
-        let root = RegKey::predef(hive);
+    for (hive, flags) in &hive_searches {
+        let root = RegKey::predef(*hive);
 
-        let subkey = match root.open_subkey_with_flags(&subkey_path, flags) {
+        let subkey = match root.open_subkey_with_flags(&subkey_path, *flags) {
             Ok(k) => k,
             Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => {
                 return DetectionResult::Unavailable {

--- a/crates/astro-up-core/src/lifecycle.rs
+++ b/crates/astro-up-core/src/lifecycle.rs
@@ -858,7 +858,10 @@ mod tests {
     fn config_to_toml_output() {
         let config = DetectionConfig {
             method: crate::types::DetectionMethod::Registry,
-            registry_key: Some("NINA 2".into()),
+            registry_key: Some(
+                r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1"
+                    .into(),
+            ),
             registry_value: Some("DisplayVersion".into()),
             file_path: None,
             version_regex: None,
@@ -873,6 +876,6 @@ mod tests {
         let toml = LifecycleRunner::config_to_toml(&config);
         assert!(toml.starts_with("[detection]"));
         assert!(toml.contains("registry"));
-        assert!(toml.contains("NINA 2"));
+        assert!(toml.contains("NINA 2_is1"));
     }
 }

--- a/crates/astro-up-core/tests/catalog_detection_roundtrip.rs
+++ b/crates/astro-up-core/tests/catalog_detection_roundtrip.rs
@@ -122,7 +122,8 @@ fn create_test_catalog(dir: &std::path::Path) -> std::path::PathBuf {
     )
     .unwrap();
 
-    // Insert detection with full fields including fallback_config JSON
+    // Insert detection with full fields including fallback_config JSON.
+    // Registry keys use absolute paths matching the format expected by registry::detect().
     let fallback_json = serde_json::json!({
         "method": "pe_file",
         "file_path": "C:\\Program Files\\NINA\\NINA.exe",
@@ -137,7 +138,7 @@ fn create_test_catalog(dir: &std::path::Path) -> std::path::PathBuf {
             "nina",
             "registry",
             Option::<String>::None,
-            "NINA 2",
+            r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1",
             "DisplayVersion",
             Option::<String>::None,
             "{B3A4F860-DA18-4B76-8E4A-3E29C2C01738}",
@@ -191,7 +192,10 @@ fn detection_config_roundtrip_with_fallback() {
 
     let config = config.unwrap();
     assert_eq!(config.method, DetectionMethod::Registry);
-    assert_eq!(config.registry_key.as_deref(), Some("NINA 2"));
+    assert_eq!(
+        config.registry_key.as_deref(),
+        Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1")
+    );
     assert_eq!(config.registry_value.as_deref(), Some("DisplayVersion"));
     assert!(config.file_path.is_none());
     assert_eq!(
@@ -276,7 +280,7 @@ fn detection_config_no_fallback() {
         [],
     ).unwrap();
     conn.execute(
-        "INSERT INTO detection (package_id, method, registry_key, registry_value) VALUES ('phd2','registry','PHD2','DisplayVersion')",
+        r"INSERT INTO detection (package_id, method, registry_key, registry_value) VALUES ('phd2','registry','HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PHDGuiding2_is1','DisplayVersion')",
         [],
     ).unwrap();
     conn.execute("INSERT INTO meta VALUES ('schema_version','1')", [])
@@ -292,7 +296,10 @@ fn detection_config_no_fallback() {
     let config = reader.detection_config(&id).unwrap().unwrap();
 
     assert_eq!(config.method, DetectionMethod::Registry);
-    assert_eq!(config.registry_key.as_deref(), Some("PHD2"));
+    assert_eq!(
+        config.registry_key.as_deref(),
+        Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PHDGuiding2_is1")
+    );
     assert!(config.fallback.is_none());
     assert!(config.file_path.is_none());
     assert!(config.version_regex.is_none());

--- a/crates/astro-up-core/tests/catalog_detection_roundtrip.rs
+++ b/crates/astro-up-core/tests/catalog_detection_roundtrip.rs
@@ -298,7 +298,9 @@ fn detection_config_no_fallback() {
     assert_eq!(config.method, DetectionMethod::Registry);
     assert_eq!(
         config.registry_key.as_deref(),
-        Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PHDGuiding2_is1")
+        Some(
+            r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PHDGuiding2_is1"
+        )
     );
     assert!(config.fallback.is_none());
     assert!(config.file_path.is_none());

--- a/crates/astro-up-core/tests/create_fixture_catalog.rs
+++ b/crates/astro-up-core/tests/create_fixture_catalog.rs
@@ -224,6 +224,24 @@ fn create_fixture_catalog() {
             None,
             false,
         ),
+        (
+            "astap",
+            "2024.12.28",
+            "https://www.hnsky.org/astap_setup.exe",
+            None,
+            "2026-01-20T10:00:00Z",
+            None,
+            false,
+        ),
+        (
+            "sharpcap",
+            "4.1.0",
+            "https://www.sharpcap.co.uk/downloads/SharpCap_setup.exe",
+            None,
+            "2026-02-15T10:00:00Z",
+            None,
+            false,
+        ),
     ];
 
     for (pid, ver, url, sha, disc, rn, pre) in &versions {
@@ -236,12 +254,17 @@ fn create_fixture_catalog() {
     }
 
     // Insert detection configs
+    //
+    // Registry keys must be absolute paths starting with HKEY_LOCAL_MACHINE\ or
+    // HKEY_CURRENT_USER\ — matching the format used by manifest TOML files and
+    // expected by registry::detect(). Bare subkey names are accepted as a
+    // backward-compatible fallback but should not be used in new data.
     let detections = vec![
         (
             "nina",
             "registry",
             None::<&str>,           // file_path
-            Some("NINA 2"),         // registry_key
+            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1"), // registry_key
             Some("DisplayVersion"), // registry_value
             None::<&str>,           // version_regex
             None::<&str>,           // product_code
@@ -249,13 +272,13 @@ fn create_fixture_catalog() {
             None::<&str>,           // inf_provider
             None::<&str>,           // device_class
             None::<&str>,           // inf_name
-            Some(r#"{"method":"pe_file","file_path":"C:\\Program Files\\NINA\\NINA.exe"}"#), // fallback_config
+            Some(r#"{"method":"pe_file","file_path":"{program_dir}\\NINA\\NINA.exe"}"#), // fallback_config
         ),
         (
             "phd2",
             "registry",
             None,
-            Some("PHD2"),
+            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PHDGuiding2_is1"),
             Some("DisplayVersion"),
             None,
             None,
@@ -269,7 +292,7 @@ fn create_fixture_catalog() {
             "ascom-platform",
             "registry",
             None,
-            Some("ASCOM Platform 6"),
+            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\ASCOM Platform 6_is1"),
             Some("DisplayVersion"),
             Some(r"^(\d+\.\d+)"),
             Some("{B3A4F860-DA18-4B76-8E4A-3E29C2C01738}"),
@@ -283,7 +306,7 @@ fn create_fixture_catalog() {
             "astap",
             "registry",
             None,
-            Some("AppName=ASTAP, the Astrometric STAcking Program,~D52A8A79_is1"),
+            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\AppName=ASTAP, the Astrometric STAcking Program,~D52A8A79_is1"),
             Some("DisplayVersion"),
             None,
             None,
@@ -291,7 +314,21 @@ fn create_fixture_catalog() {
             None,
             None,
             None,
-            Some(r#"{"method":"pe_file","file_path":"C:\\Program Files\\astap\\astap.exe"}"#),
+            Some(r#"{"method":"file_exists","file_path":"{program_dir}\\astap\\astap.exe"}"#),
+        ),
+        (
+            "sharpcap",
+            "registry",
+            None,
+            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\SharpCap 4_is1"),
+            Some("DisplayVersion"),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            Some(r#"{"method":"pe_file","file_path":"{program_dir}\\SharpCap\\SharpCap.exe"}"#),
         ),
     ];
 

--- a/crates/astro-up-core/tests/create_fixture_catalog.rs
+++ b/crates/astro-up-core/tests/create_fixture_catalog.rs
@@ -263,22 +263,26 @@ fn create_fixture_catalog() {
         (
             "nina",
             "registry",
-            None::<&str>,           // file_path
-            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1"), // registry_key
+            None::<&str>, // file_path
+            Some(
+                r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\NINA 2_is1",
+            ), // registry_key
             Some("DisplayVersion"), // registry_value
-            None::<&str>,           // version_regex
-            None::<&str>,           // product_code
-            None::<&str>,           // upgrade_code
-            None::<&str>,           // inf_provider
-            None::<&str>,           // device_class
-            None::<&str>,           // inf_name
+            None::<&str>, // version_regex
+            None::<&str>, // product_code
+            None::<&str>, // upgrade_code
+            None::<&str>, // inf_provider
+            None::<&str>, // device_class
+            None::<&str>, // inf_name
             Some(r#"{"method":"pe_file","file_path":"{program_dir}\\NINA\\NINA.exe"}"#), // fallback_config
         ),
         (
             "phd2",
             "registry",
             None,
-            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PHDGuiding2_is1"),
+            Some(
+                r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\PHDGuiding2_is1",
+            ),
             Some("DisplayVersion"),
             None,
             None,
@@ -292,7 +296,9 @@ fn create_fixture_catalog() {
             "ascom-platform",
             "registry",
             None,
-            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\ASCOM Platform 6_is1"),
+            Some(
+                r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\ASCOM Platform 6_is1",
+            ),
             Some("DisplayVersion"),
             Some(r"^(\d+\.\d+)"),
             Some("{B3A4F860-DA18-4B76-8E4A-3E29C2C01738}"),
@@ -306,7 +312,9 @@ fn create_fixture_catalog() {
             "astap",
             "registry",
             None,
-            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\AppName=ASTAP, the Astrometric STAcking Program,~D52A8A79_is1"),
+            Some(
+                r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\AppName=ASTAP, the Astrometric STAcking Program,~D52A8A79_is1",
+            ),
             Some("DisplayVersion"),
             None,
             None,
@@ -320,7 +328,9 @@ fn create_fixture_catalog() {
             "sharpcap",
             "registry",
             None,
-            Some(r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\SharpCap 4_is1"),
+            Some(
+                r"HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\SharpCap 4_is1",
+            ),
             Some("DisplayVersion"),
             None,
             None,

--- a/crates/astro-up-core/tests/detect_chain.rs
+++ b/crates/astro-up-core/tests/detect_chain.rs
@@ -93,29 +93,61 @@ async fn chain_exhausted_returns_not_installed() {
 }
 
 #[tokio::test]
-async fn registry_rejects_relative_key() {
-    // registry_key without HKEY_ prefix should return Unavailable, not silently fail
+async fn registry_bare_subkey_returns_unavailable_on_non_windows() {
+    // Bare subkey names (e.g., "PHD 2_is1") are accepted as valid registry keys
+    // (auto-prefixed with the Uninstall path on Windows). On non-Windows, they
+    // return Unavailable because registry detection requires Windows.
     let config = registry_config("PHD 2_is1");
+    let resolver = PathResolver::new();
+    let result = detect::run_chain(&config, &resolver, None, None).await;
+
+    if cfg!(not(windows)) {
+        match result {
+            DetectionResult::Unavailable { reason } => {
+                assert!(
+                    reason.contains("requires Windows"),
+                    "expected 'requires Windows', got: {reason}"
+                );
+            }
+            other => panic!("expected Unavailable on non-Windows, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn registry_rejects_relative_software_path() {
+    // Keys starting with "SOFTWARE\" are not absolute (missing HKEY_ prefix) and
+    // are not bare subkey names — these should be rejected with a clear error.
+    let config = registry_config(r"SOFTWARE\Some\Key");
     let resolver = PathResolver::new();
     let result = detect::run_chain(&config, &resolver, None, None).await;
 
     match result {
         DetectionResult::Unavailable { reason } => {
-            assert!(
-                reason.contains("absolute path"),
-                "expected absolute path error, got: {reason}"
-            );
+            if cfg!(windows) {
+                // On Windows: explicit "absolute path" rejection
+                assert!(
+                    reason.contains("absolute path"),
+                    "expected absolute path error, got: {reason}"
+                );
+            } else {
+                // On non-Windows: generic "requires Windows" (validated with tracing::warn)
+                assert!(
+                    reason.contains("requires Windows"),
+                    "expected 'requires Windows', got: {reason}"
+                );
+            }
         }
-        other => panic!("expected Unavailable for relative key, got {other:?}"),
+        other => panic!("expected Unavailable for relative SOFTWARE path, got {other:?}"),
     }
 }
 
 #[tokio::test]
-async fn registry_rejects_relative_key_falls_through_to_pe() {
+async fn registry_relative_path_falls_through_to_pe() {
     // Chain should continue to PE fallback when registry key is invalid
     let config = DetectionConfig {
         fallback: Some(Box::new(pe_config("tests/fixtures/test.exe"))),
-        ..registry_config("SOFTWARE\\Some\\Key")
+        ..registry_config(r"SOFTWARE\Some\Key")
     };
 
     let resolver = PathResolver::new();
@@ -131,6 +163,30 @@ async fn registry_rejects_relative_key_falls_through_to_pe() {
                 assert_eq!(method, DetectionMethod::PeFile);
             }
             other => panic!("expected PE fallback after invalid registry key, got {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn registry_bare_subkey_falls_through_to_pe_on_non_windows() {
+    // Bare subkey name returns Unavailable on non-Windows (no registry), chain falls to PE
+    let config = DetectionConfig {
+        fallback: Some(Box::new(pe_config("tests/fixtures/test.exe"))),
+        ..registry_config("NINA 2_is1")
+    };
+
+    let resolver = PathResolver::new();
+    let result = detect::run_chain(&config, &resolver, None, None).await;
+
+    if cfg!(not(windows)) {
+        match result {
+            DetectionResult::Installed {
+                version, method, ..
+            } => {
+                assert_eq!(version.raw, "3.2.1");
+                assert_eq!(method, DetectionMethod::PeFile);
+            }
+            other => panic!("expected PE fallback for bare subkey on non-Windows, got {other:?}"),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Fix root cause of detection failures for packages whose detection config was generated by the lifecycle discovery workflow
- `discovery.rs` stored bare subkey names (e.g. `NINA 2_is1`) instead of absolute registry paths — `registry::detect()` rejected them all as invalid
- Add backward-compatible handling of bare subkeys in `registry.rs` (auto-prefixes standard Uninstall path, searches HKLM 64/32-bit + HKCU)
- Add structured tracing to the detection chain runner for easier debugging of silent failures
- Update all test fixtures and snapshots to use absolute registry keys

## Test plan
- [ ] All 291 existing tests pass (unit + integration)
- [ ] Verify on .111: ASTAP, ASCOM Remote Server, SharpCap now detected after catalog refresh
- [ ] Run lifecycle discovery to confirm new configs use absolute paths
