### PR TITLE
fix: disable backup UI behind feature flag

### DIFF
--- a/frontend/src/App.test.ts
+++ b/frontend/src/App.test.ts
@@ -60,7 +60,7 @@ describe("App", () => {
     expect(wrapper.text()).toContain("Dashboard");
     expect(wrapper.text()).toContain("Catalog");
     expect(wrapper.text()).toContain("Installed");
-    expect(wrapper.text()).toContain("Backup");
+    expect(wrapper.text()).not.toContain("Backup");
     expect(wrapper.text()).toContain("Settings");
   });
 });
@@ -92,15 +92,15 @@ describe("View smoke tests", () => {
     expect(wrapper.text()).toContain("Re-scan");
   });
 
-  it("Backup renders empty state", async () => {
+  it("Backup route redirects to dashboard when feature is disabled", async () => {
     const wrapper = mountApp();
     await router.push("/backup");
     await router.isReady();
-    expect(wrapper.text()).toContain("Backup");
-    expect(wrapper.text()).toContain("No backups yet");
+    expect(router.currentRoute.value.name).toBe("dashboard");
+    expect(wrapper.text()).toContain("Dashboard");
   });
 
-  it("Settings renders sidebar nav with 9 sections", async () => {
+  it("Settings renders sidebar nav with 8 sections (backup hidden)", async () => {
     const wrapper = mountApp();
     await router.push("/settings");
     await router.isReady();

--- a/frontend/src/components/detail/DetailHero.vue
+++ b/frontend/src/components/detail/DetailHero.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import Button from "primevue/button";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
+import { FEATURE_BACKUP } from "../../features";
 import PackageIcon from "../shared/PackageIcon.vue";
 import type { PackageWithStatus } from "../../types/package";
 
@@ -75,7 +76,7 @@ defineEmits<{
         @click="$emit('install')"
       />
       <Button
-        v-if="pkg.backup?.config_paths?.length"
+        v-if="FEATURE_BACKUP && pkg.backup?.config_paths?.length"
         label="Backup Now"
         icon="pi pi-database"
         severity="secondary"

--- a/frontend/src/components/installed/PackageRow.vue
+++ b/frontend/src/components/installed/PackageRow.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import Button from "primevue/button";
+import { FEATURE_BACKUP } from "../../features";
 import PackageIcon from "../shared/PackageIcon.vue";
 import type { PackageWithStatus } from "../../types/package";
 
@@ -49,7 +50,7 @@ defineEmits<{
       @click.stop
     >
       <Button
-        v-if="pkg.backup?.config_paths?.length"
+        v-if="FEATURE_BACKUP && pkg.backup?.config_paths?.length"
         icon="pi pi-database"
         label="Backup Now"
         text

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import Badge from "primevue/badge";
+import { FEATURE_BACKUP } from "../../features";
 import { useSoftwareList } from "../../composables/useInvoke";
 import type { PackageWithStatus } from "../../types/package";
 
@@ -10,13 +11,14 @@ const updateCount = computed(() =>
   ((software.value ?? []) as PackageWithStatus[]).filter((p) => p.update_available).length,
 );
 
-const navItems = [
+const allNavItems = [
   { to: "/", label: "Dashboard", icon: "pi-home", exact: true },
   { to: "/catalog", label: "Catalog", icon: "pi-th-large" },
   { to: "/installed", label: "Installed", icon: "pi-check-circle" },
-  { to: "/backup", label: "Backup", icon: "pi-database" },
+  { to: "/backup", label: "Backup", icon: "pi-database", feature: FEATURE_BACKUP },
   { to: "/settings", label: "Settings", icon: "pi-cog" },
 ];
+const navItems = allNavItems.filter((item) => item.feature !== false);
 </script>
 
 <template>

--- a/frontend/src/composables/useKeyboard.ts
+++ b/frontend/src/composables/useKeyboard.ts
@@ -11,12 +11,11 @@ export function useKeyboard(options: {
   const router = useRouter();
   const keys = useMagicKeys();
 
-  // Ctrl+1-5: Navigate to pages
+  // Ctrl+1-4: Navigate to pages
   whenever(keys["ctrl+1"]!, () => router.push("/"));
   whenever(keys["ctrl+2"]!, () => router.push("/catalog"));
   whenever(keys["ctrl+3"]!, () => router.push("/installed"));
-  whenever(keys["ctrl+4"]!, () => router.push("/backup"));
-  whenever(keys["ctrl+5"]!, () => router.push("/settings"));
+  whenever(keys["ctrl+4"]!, () => router.push("/settings"));
 
   // Ctrl+F: Focus search
   function handleKeydown(e: KeyboardEvent) {

--- a/frontend/src/features.ts
+++ b/frontend/src/features.ts
@@ -1,0 +1,4 @@
+/** Feature flags for conditionally enabling/disabling UI sections. */
+
+/** Backup & restore UI — disabled until the feature is properly designed. */
+export const FEATURE_BACKUP = false;

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,4 +1,5 @@
 import { createRouter, createWebHashHistory } from "vue-router";
+import { FEATURE_BACKUP } from "../features";
 import { logger } from "../utils/logger";
 
 const router = createRouter({
@@ -29,6 +30,7 @@ const router = createRouter({
       path: "/backup",
       name: "backup",
       component: () => import("../views/BackupView.vue"),
+      beforeEnter: () => FEATURE_BACKUP || { name: "dashboard" },
     },
     {
       path: "/settings",

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -6,6 +6,7 @@ import Button from "primevue/button";
 import ConfirmDialog from "../components/shared/ConfirmDialog.vue";
 import SurveyDialog from "../components/shared/SurveyDialog.vue";
 import PackageIcon from "../components/shared/PackageIcon.vue";
+import { FEATURE_BACKUP } from "../features";
 import { useSoftwareList, useScanInstalled, useUpdateSoftware, useLastScan } from "../composables/useInvoke";
 import { useOperations } from "../composables/useOperations";
 import { useUpdateQueue } from "../composables/useUpdateQueue";
@@ -127,6 +128,7 @@ function confirmSingleUpdate() {
         </div>
       </div>
       <div
+        v-if="FEATURE_BACKUP"
         class="stat-card card clickable"
         @click="router.push('/backup')"
       >

--- a/frontend/src/views/InstalledView.vue
+++ b/frontend/src/views/InstalledView.vue
@@ -11,6 +11,7 @@ import EmptyState from "../components/shared/EmptyState.vue";
 import { useSoftwareList, useUpdateSoftware, useScanInstalled, useCreateBackup } from "../composables/useInvoke";
 import { useOperations } from "../composables/useOperations";
 import { useUpdateQueue } from "../composables/useUpdateQueue";
+import { FEATURE_BACKUP } from "../features";
 import type { PackageWithStatus } from "../types/package";
 
 const router = useRouter();
@@ -68,6 +69,7 @@ function confirmScan() {
 }
 
 function handleBackup(pkg: PackageWithStatus) {
+  if (!FEATURE_BACKUP) return;
   if (!startOperation(pkg.id, `Backing up ${pkg.name}`)) return;
   backupMutation.mutate([]);
 }

--- a/frontend/src/views/PackageDetailView.vue
+++ b/frontend/src/views/PackageDetailView.vue
@@ -6,6 +6,7 @@ import TabList from "primevue/tablist";
 import Tab from "primevue/tab";
 import TabPanels from "primevue/tabpanels";
 import TabPanel from "primevue/tabpanel";
+import { FEATURE_BACKUP } from "../features";
 import DetailHero from "../components/detail/DetailHero.vue";
 import OverviewTab from "../components/detail/OverviewTab.vue";
 import VersionsTab from "../components/detail/VersionsTab.vue";
@@ -117,7 +118,7 @@ function confirmBackup() {
               Versions
             </Tab>
             <Tab
-              v-if="pkg.backup?.config_paths?.length"
+              v-if="FEATURE_BACKUP && pkg.backup?.config_paths?.length"
               value="2"
             >
               Backup
@@ -155,6 +156,7 @@ function confirmBackup() {
     </template>
 
     <ConfirmDialog
+      v-if="FEATURE_BACKUP"
       v-model:visible="showBackupConfirm"
       title="Backup Now"
       :message="`Create a backup of ${pkg?.name ?? 'this package'}?`"

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -13,6 +13,7 @@ import NetworkSection from "../components/settings/NetworkSection.vue";
 import PathsSection from "../components/settings/PathsSection.vue";
 import LoggingSection from "../components/settings/LoggingSection.vue";
 import AboutSection from "../components/settings/AboutSection.vue";
+import { FEATURE_BACKUP } from "../features";
 import { useConfig, useSaveConfig } from "../composables/useInvoke";
 import { logger } from "../utils/logger";
 import type { AppConfig } from "../types/config";
@@ -25,17 +26,18 @@ const activeSection = ref("general");
 const showResetConfirm = ref(false);
 let saveTimer: ReturnType<typeof setTimeout> | null = null;
 
-const sections = [
+const allSections = [
   { id: "general", label: "General", icon: "pi-cog" },
   { id: "startup", label: "Startup", icon: "pi-power-off" },
   { id: "notifications", label: "Notifications", icon: "pi-bell" },
-  { id: "backup", label: "Backup", icon: "pi-database" },
+  { id: "backup", label: "Backup", icon: "pi-database", feature: FEATURE_BACKUP },
   { id: "catalog", label: "Catalog", icon: "pi-th-large" },
   { id: "network", label: "Network", icon: "pi-globe" },
   { id: "paths", label: "Paths", icon: "pi-folder" },
   { id: "logging", label: "Logging", icon: "pi-list" },
   { id: "about", label: "About", icon: "pi-info-circle" },
 ];
+const sections = allSections.filter((s) => s.feature !== false);
 
 const defaultConfig: AppConfig = {
   ui: {


### PR DESCRIPTION
## Summary
- Add `FEATURE_BACKUP = false` flag in `frontend/src/features.ts` to hide all backup UI
- Backup doesn't work yet (NINA reports "no backup paths configured") — hiding until proper UX design
- All backend code, types, and mock data kept intact — flip flag to `true` to re-enable

### Gated locations (11 files)
- Sidebar: "Backup" nav item filtered out
- Router: `/backup` route redirects to dashboard
- Dashboard: "Backups" stat card hidden
- DetailHero: "Backup Now" button hidden
- PackageRow: "Backup Now" button hidden
- PackageDetailView: Backup tab + confirm dialog hidden
- InstalledView: backup handler gated with early return
- SettingsView: "Backup" section filtered from sidebar nav
- useKeyboard: Ctrl+4 shortcut reassigned to Settings
- App.test.ts: 3 tests updated

## Test plan
- [ ] Verify no backup UI visible anywhere: sidebar, dashboard, installed, detail, settings
- [ ] Verify Ctrl+4 goes to Settings
- [ ] Set `FEATURE_BACKUP = true` and verify all backup UI reappears
