### PR TITLE
fix: add ledger entries for packages detected with unknown version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.23"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.22"
+version = "0.1.23"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/crates/astro-up-core/src/detect/scanner.rs
+++ b/crates/astro-up-core/src/detect/scanner.rs
@@ -253,8 +253,15 @@ impl<P: PackageSource, L: LedgerStore> Scanner<P, L> {
 
         // Upsert installed packages
         for pd in results {
-            if let DetectionResult::Installed { ref version, .. } = pd.result {
-                self.ledger.upsert_acknowledged(&pd.package_id, version)?;
+            match &pd.result {
+                DetectionResult::Installed { version, .. } => {
+                    self.ledger.upsert_acknowledged(&pd.package_id, version)?;
+                }
+                DetectionResult::InstalledUnknownVersion { .. } => {
+                    let sentinel = Version::parse("0.0.0");
+                    self.ledger.upsert_acknowledged(&pd.package_id, &sentinel)?;
+                }
+                _ => {}
             }
         }
 
@@ -526,6 +533,62 @@ mod tests {
         // "gone-app" should be removed, "test-app" should be added
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].package_id, "test-app");
+    }
+
+    #[test]
+    fn ledger_sync_creates_entry_for_unknown_version() {
+        let ledger = MockLedger::new();
+        let packages = MockPackages(vec![]);
+        let scanner = Scanner::new(packages, ledger);
+
+        let results = vec![PackageDetection {
+            package_id: "astap".into(),
+            result: DetectionResult::InstalledUnknownVersion {
+                method: DetectionMethod::Registry,
+                install_path: Some("C:\\Program Files\\ASTAP".into()),
+            },
+        }];
+
+        scanner.sync_ledger(&results).unwrap();
+
+        let entries = scanner.ledger.list_acknowledged().unwrap();
+        assert_eq!(
+            entries.len(),
+            1,
+            "InstalledUnknownVersion must create a ledger entry"
+        );
+        assert_eq!(entries[0].package_id, "astap");
+        assert_eq!(
+            entries[0].version.raw, "0.0.0",
+            "sentinel version for unknown"
+        );
+    }
+
+    #[test]
+    fn ledger_sync_removes_stale_when_unknown_version_present() {
+        let ledger = MockLedger::new();
+        // Pre-populate with a package that will no longer be detected
+        ledger
+            .upsert_acknowledged("gone-app", &Version::parse("1.0.0"))
+            .unwrap();
+
+        let packages = MockPackages(vec![]);
+        let scanner = Scanner::new(packages, ledger);
+
+        // Only "astap" is detected (with unknown version)
+        let results = vec![PackageDetection {
+            package_id: "astap".into(),
+            result: DetectionResult::InstalledUnknownVersion {
+                method: DetectionMethod::Registry,
+                install_path: None,
+            },
+        }];
+
+        scanner.sync_ledger(&results).unwrap();
+
+        let entries = scanner.ledger.list_acknowledged().unwrap();
+        assert_eq!(entries.len(), 1, "stale entry should be removed");
+        assert_eq!(entries[0].package_id, "astap");
     }
 
     #[tokio::test]

--- a/crates/astro-up-core/src/engine/orchestrator.rs
+++ b/crates/astro-up-core/src/engine/orchestrator.rs
@@ -609,6 +609,13 @@ where
                         install_status
                     }
                 }
+                crate::detect::DetectionResult::InstalledUnknownVersion { .. } => {
+                    tracing::info!(
+                        package = %pkg_id,
+                        "post-install detected but version unknown — verification skipped"
+                    );
+                    install_status
+                }
                 _ => {
                     tracing::warn!(
                         package = %pkg_id,


### PR DESCRIPTION
## Summary
- Fix packages detected with unknown version (e.g. ASTAP via registry key without `DisplayVersion`) not appearing in the Installed view
- `sync_ledger` now creates ledger entries for `InstalledUnknownVersion` with sentinel version `0.0.0`
- Post-install verification in orchestrator now handles `InstalledUnknownVersion` as success instead of logging "not found"

## Root Cause
`sync_ledger` only matched `DetectionResult::Installed { version }` — packages detected as `InstalledUnknownVersion` were counted in scan results but never got ledger entries, so the frontend "Installed" view (which is ledger-filtered) never showed them.

## Test plan
- [ ] 2 new unit tests pass: `ledger_sync_creates_entry_for_unknown_version`, `ledger_sync_removes_stale_when_unknown_version_present`
- [ ] Install ASTAP on .111, run scan — verify ASTAP appears in Installed view
- [ ] Install a package via Astro-Up that returns `InstalledUnknownVersion` post-install — verify no "not found" warning in logs
