### PR TITLE
feat: add reinstall option for installed packages

### DIFF
--- a/frontend/src/components/detail/DetailHero.vue
+++ b/frontend/src/components/detail/DetailHero.vue
@@ -13,6 +13,7 @@ defineProps<{
 defineEmits<{
   install: [];
   update: [];
+  reinstall: [];
   backup: [];
 }>();
 </script>
@@ -62,11 +63,12 @@ defineEmits<{
       />
       <Button
         v-else-if="pkg.installed_version"
-        label="Installed"
-        icon="pi pi-check"
-        severity="success"
+        label="Reinstall"
+        icon="pi pi-refresh"
+        severity="secondary"
         outlined
-        disabled
+        :disabled="actionsDisabled"
+        @click="$emit('reinstall')"
       />
       <Button
         v-else

--- a/frontend/src/components/installed/PackageRow.vue
+++ b/frontend/src/components/installed/PackageRow.vue
@@ -11,6 +11,7 @@ defineProps<{
 
 defineEmits<{
   update: [];
+  reinstall: [];
   backup: [];
   detail: [];
 }>();
@@ -68,6 +69,17 @@ defineEmits<{
         class="action-btn"
         :disabled="actionsDisabled"
         @click="$emit('update')"
+      />
+      <Button
+        v-else
+        label="Reinstall"
+        icon="pi pi-refresh"
+        text
+        size="small"
+        severity="secondary"
+        class="action-btn"
+        :disabled="actionsDisabled"
+        @click="$emit('reinstall')"
       />
     </div>
   </div>

--- a/frontend/src/views/InstalledView.vue
+++ b/frontend/src/views/InstalledView.vue
@@ -8,7 +8,7 @@ import Button from "primevue/button";
 import PackageRow from "../components/installed/PackageRow.vue";
 import ConfirmDialog from "../components/shared/ConfirmDialog.vue";
 import EmptyState from "../components/shared/EmptyState.vue";
-import { useSoftwareList, useUpdateSoftware, useScanInstalled, useCreateBackup } from "../composables/useInvoke";
+import { useSoftwareList, useInstallSoftware, useUpdateSoftware, useScanInstalled, useCreateBackup } from "../composables/useInvoke";
 import { useOperations } from "../composables/useOperations";
 import { useUpdateQueue } from "../composables/useUpdateQueue";
 import { FEATURE_BACKUP } from "../features";
@@ -16,6 +16,7 @@ import type { PackageWithStatus } from "../types/package";
 
 const router = useRouter();
 const { data: software, isLoading } = useSoftwareList(() => "installed");
+const installMutation = useInstallSoftware();
 const updateMutation = useUpdateSoftware();
 const scanMutation = useScanInstalled();
 const backupMutation = useCreateBackup();
@@ -25,7 +26,9 @@ const { enqueue, isActive: queueActive } = useUpdateQueue();
 const searchFilter = ref("");
 const showUpdateConfirm = ref(false);
 const showUpdateAllConfirm = ref(false);
+const showReinstallConfirm = ref(false);
 const pendingUpdatePkg = ref<PackageWithStatus | null>(null);
+const pendingReinstallPkg = ref<PackageWithStatus | null>(null);
 
 // Backend "installed" filter returns only packages with ledger entries (post-scan).
 // No client-side filtering needed — all returned packages are installed.
@@ -66,6 +69,18 @@ function confirmUpdateAll() {
 function confirmScan() {
   if (!startOperation("scan", "Scanning installed software")) return;
   scanMutation.mutate();
+}
+
+function handleReinstall(pkg: PackageWithStatus) {
+  pendingReinstallPkg.value = pkg;
+  showReinstallConfirm.value = true;
+}
+
+function confirmReinstall() {
+  const pkg = pendingReinstallPkg.value;
+  if (!pkg || !startOperation(pkg.id, `Reinstalling ${pkg.name}`)) return;
+  installMutation.mutate(pkg.id);
+  pendingReinstallPkg.value = null;
 }
 
 function handleBackup(pkg: PackageWithStatus) {
@@ -134,6 +149,7 @@ function handleBackup(pkg: PackageWithStatus) {
           :pkg="pkg"
           :actions-disabled="isRunning || queueActive"
           @update="handleUpdate(pkg)"
+          @reinstall="handleReinstall(pkg)"
           @backup="handleBackup(pkg)"
           @detail="router.push({ name: 'package-detail', params: { id: pkg.id } })"
         />
@@ -184,6 +200,16 @@ function handleBackup(pkg: PackageWithStatus) {
         </li>
       </ul>
     </ConfirmDialog>
+
+    <ConfirmDialog
+      v-model:visible="showReinstallConfirm"
+      title="Reinstall Package"
+      :message="`Download and reinstall ${pendingReinstallPkg?.name}?`"
+      icon="pi-refresh"
+      confirm-label="Reinstall"
+      severity="secondary"
+      @confirm="confirmReinstall"
+    />
 
   </div>
 </template>

--- a/frontend/src/views/InstalledView.vue
+++ b/frontend/src/views/InstalledView.vue
@@ -207,7 +207,6 @@ function handleBackup(pkg: PackageWithStatus) {
       :message="`Download and reinstall ${pendingReinstallPkg?.name}?`"
       icon="pi-refresh"
       confirm-label="Reinstall"
-      severity="secondary"
       @confirm="confirmReinstall"
     />
 

--- a/frontend/src/views/PackageDetailView.vue
+++ b/frontend/src/views/PackageDetailView.vue
@@ -61,6 +61,18 @@ function handleUpdate() {
   updateMutation.mutate(pkg.value.id);
 }
 
+const showReinstallConfirm = ref(false);
+
+function handleReinstall() {
+  showReinstallConfirm.value = true;
+}
+
+function confirmReinstall() {
+  if (!pkg.value) return;
+  logger.debug("PackageDetailView", `reinstall confirmed: ${pkg.value.id}`);
+  installMutation.mutate(pkg.value.id);
+}
+
 function handleBackup() {
   logger.debug("PackageDetailView", `backup clicked: ${pkg.value?.id}`);
   showBackupConfirm.value = true;
@@ -102,6 +114,7 @@ function confirmBackup() {
         :actions-disabled="actionsDisabled"
         @install="handleInstall"
         @update="handleUpdate"
+        @reinstall="handleReinstall"
         @backup="handleBackup"
       />
 
@@ -154,6 +167,16 @@ function confirmBackup() {
         </Tabs>
       </div>
     </template>
+
+    <ConfirmDialog
+      v-model:visible="showReinstallConfirm"
+      title="Reinstall Package"
+      :message="`Download and reinstall ${pkg?.name ?? 'this package'}?`"
+      icon="pi-refresh"
+      confirm-label="Reinstall"
+      severity="secondary"
+      @confirm="confirmReinstall"
+    />
 
     <ConfirmDialog
       v-if="FEATURE_BACKUP"

--- a/frontend/src/views/PackageDetailView.vue
+++ b/frontend/src/views/PackageDetailView.vue
@@ -174,7 +174,6 @@ function confirmBackup() {
       :message="`Download and reinstall ${pkg?.name ?? 'this package'}?`"
       icon="pi-refresh"
       confirm-label="Reinstall"
-      severity="secondary"
       @confirm="confirmReinstall"
     />
 


### PR DESCRIPTION
## Summary
- Add "Reinstall" button for installed packages that don't have an update available
- Replaces the disabled "Installed" indicator with an actionable "Reinstall" button
- Uses the existing `install_software` backend command — no backend changes needed
- Includes confirmation dialog before reinstalling

### Changes (4 files)
- `DetailHero.vue`: "Installed" disabled button → "Reinstall" button with confirmation
- `PackageRow.vue`: Added "Reinstall" text button in the actions column for up-to-date packages
- `PackageDetailView.vue`: Wired reinstall handler + confirmation dialog
- `InstalledView.vue`: Wired reinstall handler + confirmation dialog

## Test plan
- [ ] Open an installed, up-to-date package — verify "Reinstall" button appears instead of disabled "Installed"
- [ ] Click Reinstall — verify confirmation dialog appears
- [ ] Confirm — verify install operation starts (downloads + runs installer)
- [ ] In Installed view, verify "Reinstall" button appears on up-to-date packages
