### PR TITLE
fix: add force-tag-creation to prevent ghost release-please PRs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -4,6 +4,7 @@
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
   "draft": true,
+  "force-tag-creation": true,
   "include-component-in-tag": false,
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary
Add `"force-tag-creation": true` to `release-please-config.json`.

## Root Cause
With `"draft": true`, GitHub defers git tag creation until the draft release is published. When release-please runs again (triggered by the next push to main), it can't find the previous release's tag, so it falls back to scanning ALL commits — producing a massive changelog with the entire project history.

This is a known issue: GitHub's lazy tag creation for draft releases breaks release-please's changelog detection. The `force-tag-creation` option (added in release-please v17.2.0) explicitly creates the git tag immediately on merge, even for draft releases.

## Immediate cleanup needed
- Close the bogus `chore(main): release 0.1.25` PR
- Manually create the `v0.1.24` tag once the build completes and the draft release is published

## Test plan
- [ ] Merge this PR
- [ ] Merge the next release-please PR — verify the changelog only contains commits since the last release, not the entire history
