### PR TITLE
fix: change frontend default install method from silent to interactive

### DIFF
--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -43,7 +43,7 @@ const defaultConfig: AppConfig = {
   ui: {
     theme: "system", font_size: "medium", auto_scan_on_launch: true,
     scan_interval: "on_startup",
-    default_install_scope: "user", default_install_method: "silent",
+    default_install_scope: "user", default_install_method: "interactive",
     auto_check_updates: true, check_interval: "1day",
     auto_notify_updates: true, auto_install_updates: false,
   },


### PR DESCRIPTION
## Summary
Frontend default for `default_install_method` was `"silent"` — should be `"interactive"` to match the Rust config default.

When Settings loaded with no DB value, the frontend initialized `"silent"` and persisted it on first save, overriding the correct Rust default. This caused all installers to run with `/VERYSILENT` flags even when the user expected interactive mode.

Also deleted `astro-up.db` on .111 test machine to reset to correct defaults.

## Also found
`auto_notify_updates` and `show_update_available` config settings exist in the model but nothing in the GUI reads them — notifications are not implemented yet. Separate issue.

## Test plan
- [ ] Fresh install: verify Settings shows "Interactive" for install method
- [ ] Install a package: verify installer shows its UI (not silent)
