### PR TITLE
fix: add force_reinstall flag to bypass up-to-date skip

### DIFF
--- a/crates/astro-up-cli/src/commands/install.rs
+++ b/crates/astro-up-cli/src/commands/install.rs
@@ -129,6 +129,7 @@ pub async fn handle_install(
         allow_downgrade: false,
         dry_run: false,
         confirmed: true,
+        force_reinstall: false,
         quiet,
         install_scope: state.config.ui.default_install_scope.clone(),
     };

--- a/crates/astro-up-cli/src/commands/update.rs
+++ b/crates/astro-up-cli/src/commands/update.rs
@@ -96,6 +96,7 @@ pub async fn handle_update(
         allow_downgrade: false,
         dry_run,
         confirmed: yes,
+        force_reinstall: false,
         quiet,
         install_scope: state.config.ui.default_install_scope.clone(),
     };

--- a/crates/astro-up-core/src/engine/orchestrator.rs
+++ b/crates/astro-up-core/src/engine/orchestrator.rs
@@ -52,6 +52,10 @@ pub struct UpdateRequest {
     pub dry_run: bool,
     /// The user has reviewed and confirmed the plan.
     pub confirmed: bool,
+    /// Force reinstall even when the package is already up to date.
+    /// Only effective for `plan_specific` — `plan_all` ignores this flag.
+    #[serde(default)]
+    pub force_reinstall: bool,
     /// Run installers silently (true) or show installer UI (false).
     /// Defaults to true for backward compatibility.
     #[serde(default = "default_quiet")]
@@ -836,7 +840,7 @@ where
         let mut plan = if request.packages.is_empty() {
             planner.plan_all()?
         } else {
-            planner.plan_specific(&request.packages)?
+            planner.plan_specific(&request.packages, request.force_reinstall)?
         };
         plan.quiet = request.quiet;
         plan.install_scope = request.install_scope;
@@ -1297,6 +1301,7 @@ mod tests {
             allow_downgrade: false,
             dry_run: true,
             confirmed: false,
+            force_reinstall: false,
             quiet: false,
             install_scope: crate::config::InstallScope::default(),
         };

--- a/crates/astro-up-core/src/engine/planner.rs
+++ b/crates/astro-up-core/src/engine/planner.rs
@@ -717,7 +717,10 @@ mod tests {
         assert_eq!(plan.items[0].package_id, PackageId::new("nina").unwrap());
         assert_eq!(plan.items[0].current_version, Version::parse("2.0.0"));
         assert_eq!(plan.items[0].target_version, Version::parse("2.0.0"));
-        assert!(plan.skipped.is_empty(), "UpToDate entry should not be in skipped when force_reinstall is true");
+        assert!(
+            plan.skipped.is_empty(),
+            "UpToDate entry should not be in skipped when force_reinstall is true"
+        );
     }
 
     #[test]

--- a/crates/astro-up-core/src/engine/planner.rs
+++ b/crates/astro-up-core/src/engine/planner.rs
@@ -332,11 +332,50 @@ impl UpdatePlanner {
     }
 
     /// Build an update plan for specific packages only.
-    pub fn plan_specific(&self, package_ids: &[PackageId]) -> Result<UpdatePlan, CoreError> {
+    ///
+    /// When `force_reinstall` is true, packages that are `UpToDate` are planned
+    /// as an install from the current version to the same version instead of
+    /// being skipped. This only applies to the explicitly requested packages,
+    /// not to their transitive dependencies.
+    pub fn plan_specific(
+        &self,
+        package_ids: &[PackageId],
+        force_reinstall: bool,
+    ) -> Result<UpdatePlan, CoreError> {
         let full_plan = self.plan_all()?;
 
         let update_map: HashMap<&PackageId, &PlannedUpdate> =
             full_plan.items.iter().map(|u| (&u.package_id, u)).collect();
+
+        // When force_reinstall is set, build PlannedUpdate entries for
+        // requested packages that were skipped as UpToDate.
+        let requested_set: HashSet<&PackageId> = package_ids.iter().collect();
+        let entry_map: HashMap<&PackageId, &CatalogEntry> =
+            self.entries.iter().map(|e| (&e.software.id, e)).collect();
+
+        let mut force_items: Vec<PlannedUpdate> = Vec::new();
+        if force_reinstall {
+            for skipped in &full_plan.skipped {
+                if skipped.reason == SkipReason::UpToDate
+                    && requested_set.contains(&skipped.package_id)
+                {
+                    if let Some(entry) = entry_map.get(&skipped.package_id) {
+                        if let Some(ref installed) = entry.installed_version {
+                            force_items.push(PlannedUpdate {
+                                package_id: entry.software.id.clone(),
+                                software: entry.software.clone(),
+                                current_version: installed.clone(),
+                                target_version: entry.catalog_version.clone(),
+                                version_entry: entry.version_entry.clone(),
+                                version_format: entry.version_format.clone(),
+                                has_backup_config: entry.software.backup.is_some(),
+                                dependencies: Vec::new(),
+                            });
+                        }
+                    }
+                }
+            }
+        }
 
         let mut included: HashSet<PackageId> = HashSet::new();
         let mut queue: VecDeque<PackageId> = package_ids.iter().cloned().collect();
@@ -354,17 +393,29 @@ impl UpdatePlanner {
             }
         }
 
-        let items: Vec<PlannedUpdate> = full_plan
+        // Also include force-reinstall items in the included set
+        for fi in &force_items {
+            included.insert(fi.package_id.clone());
+        }
+
+        let mut items: Vec<PlannedUpdate> = full_plan
             .items
             .into_iter()
             .filter(|u| included.contains(&u.package_id))
             .collect();
 
-        let requested: HashSet<&PackageId> = package_ids.iter().collect();
+        // Append force-reinstall items (they weren't in full_plan.items)
+        items.extend(force_items);
+
         let skipped: Vec<SkippedPackage> = full_plan
             .skipped
             .into_iter()
-            .filter(|s| requested.contains(&s.package_id))
+            .filter(|s| {
+                // Keep skipped entries for requested packages, but exclude
+                // UpToDate ones that were promoted to items by force_reinstall.
+                requested_set.contains(&s.package_id)
+                    && !(force_reinstall && s.reason == SkipReason::UpToDate)
+            })
             .collect();
 
         let warnings: Vec<String> = full_plan
@@ -606,7 +657,7 @@ mod tests {
         ];
         let planner = UpdatePlanner::new(entries);
         let plan = planner
-            .plan_specific(&[PackageId::new("nina").unwrap()])
+            .plan_specific(&[PackageId::new("nina").unwrap()], false)
             .unwrap();
         assert_eq!(plan.items.len(), 1);
         assert_eq!(plan.items[0].package_id, PackageId::new("nina").unwrap());
@@ -622,7 +673,7 @@ mod tests {
         ];
         let planner = UpdatePlanner::new(entries);
         let plan = planner
-            .plan_specific(&[PackageId::new("nina").unwrap()])
+            .plan_specific(&[PackageId::new("nina").unwrap()], false)
             .unwrap();
         assert_eq!(plan.items.len(), 3);
         let ids: Vec<String> = plan
@@ -638,7 +689,50 @@ mod tests {
     fn plan_specific_empty_ids_returns_empty() {
         let entries = vec![make_entry("nina", "1.0.0", "2.0.0", vec![])];
         let planner = UpdatePlanner::new(entries);
-        let plan = planner.plan_specific(&[]).unwrap();
+        let plan = planner.plan_specific(&[], false).unwrap();
         assert!(plan.items.is_empty());
+    }
+
+    #[test]
+    fn plan_specific_force_reinstall_promotes_up_to_date() {
+        let entries = vec![
+            make_entry("nina", "2.0.0", "2.0.0", vec![]),
+            make_entry("phd2", "1.0.0", "2.0.0", vec![]),
+        ];
+        let planner = UpdatePlanner::new(entries);
+
+        // Without force: up-to-date package is skipped
+        let plan = planner
+            .plan_specific(&[PackageId::new("nina").unwrap()], false)
+            .unwrap();
+        assert!(plan.items.is_empty());
+        assert_eq!(plan.skipped.len(), 1);
+        assert_eq!(plan.skipped[0].reason, SkipReason::UpToDate);
+
+        // With force: up-to-date package is promoted to items
+        let plan = planner
+            .plan_specific(&[PackageId::new("nina").unwrap()], true)
+            .unwrap();
+        assert_eq!(plan.items.len(), 1);
+        assert_eq!(plan.items[0].package_id, PackageId::new("nina").unwrap());
+        assert_eq!(plan.items[0].current_version, Version::parse("2.0.0"));
+        assert_eq!(plan.items[0].target_version, Version::parse("2.0.0"));
+        assert!(plan.skipped.is_empty(), "UpToDate entry should not be in skipped when force_reinstall is true");
+    }
+
+    #[test]
+    fn plan_specific_force_reinstall_only_affects_requested() {
+        let entries = vec![
+            make_entry("nina", "2.0.0", "2.0.0", vec![]),
+            make_entry("phd2", "2.0.0", "2.0.0", vec![]),
+        ];
+        let planner = UpdatePlanner::new(entries);
+
+        // Force reinstall only nina — phd2 should remain skipped
+        let plan = planner
+            .plan_specific(&[PackageId::new("nina").unwrap()], true)
+            .unwrap();
+        assert_eq!(plan.items.len(), 1);
+        assert_eq!(plan.items[0].package_id, PackageId::new("nina").unwrap());
     }
 }

--- a/crates/astro-up-core/tests/engine_planner.rs
+++ b/crates/astro-up-core/tests/engine_planner.rs
@@ -155,7 +155,7 @@ fn plan_specific_transitive_deps() {
     ];
     let planner = UpdatePlanner::new(entries);
     let plan = planner
-        .plan_specific(&[PackageId::new("nina").unwrap()])
+        .plan_specific(&[PackageId::new("nina").unwrap()], false)
         .unwrap();
 
     // nina + ascom-platform + dotnet, but NOT phd2

--- a/crates/astro-up-gui/src/commands.rs
+++ b/crates/astro-up-gui/src/commands.rs
@@ -578,6 +578,18 @@ async fn run_orchestrated_operation(
     _op_id: &OperationId,
     cancel_token: tokio_util::sync::CancellationToken,
 ) -> Result<serde_json::Value, CoreError> {
+    run_orchestrated_operation_inner(app, state, ids, _op_id, cancel_token, false).await
+}
+
+/// Like [`run_orchestrated_operation`] but with `force_reinstall` support.
+async fn run_orchestrated_operation_inner(
+    app: &AppHandle,
+    state: &AppState,
+    ids: &[&str],
+    _op_id: &OperationId,
+    cancel_token: tokio_util::sync::CancellationToken,
+    force_reinstall: bool,
+) -> Result<serde_json::Value, CoreError> {
     use astro_up_core::backup::BackupService;
     use astro_up_core::download::DownloadManager;
     use astro_up_core::engine::orchestrator::{Orchestrator, UpdateRequest};
@@ -653,6 +665,7 @@ async fn run_orchestrated_operation(
                     allow_downgrade: false,
                     dry_run: false,
                     confirmed: true,
+                    force_reinstall,
                     quiet,
                     install_scope: config.ui.default_install_scope.clone(),
                 })
@@ -781,6 +794,47 @@ pub async fn install_software(
 
     tracing::debug!(
         command = "install_software",
+        operation_id = op_id.id,
+        duration_ms = start.elapsed().as_millis() as u64,
+        "Command completed"
+    );
+    Ok(op_id)
+}
+
+#[tauri::command]
+pub async fn reinstall_software(
+    app: AppHandle,
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<OperationId, CoreError> {
+    let start = std::time::Instant::now();
+    let (op_id, token) = state.register_operation();
+    tracing::info!(
+        command = "reinstall_software",
+        package = id,
+        operation_id = op_id.id,
+        "Command invoked"
+    );
+
+    match run_orchestrated_operation_inner(&app, &state, &[&id], &op_id, token, true).await {
+        Ok(_) => {
+            tracing::info!(command = "reinstall_software", package = id, "Completed");
+        }
+        Err(e) => {
+            tracing::error!(command = "reinstall_software", package = id, error = %e, "Failed");
+            emit_event(
+                &app,
+                &Event::InstallFailed {
+                    id: id.clone(),
+                    error: e.message,
+                },
+            );
+        }
+    }
+    state.remove_operation(&op_id.id);
+
+    tracing::debug!(
+        command = "reinstall_software",
         operation_id = op_id.id,
         duration_ms = start.elapsed().as_millis() as u64,
         "Command completed"

--- a/crates/astro-up-gui/src/lib.rs
+++ b/crates/astro-up-gui/src/lib.rs
@@ -349,6 +349,7 @@ pub fn run() {
             commands::save_config,
             commands::scan_installed,
             commands::install_software,
+            commands::reinstall_software,
             commands::update_software,
             commands::update_all,
             commands::create_backup,

--- a/frontend/src/composables/useInvoke.ts
+++ b/frontend/src/composables/useInvoke.ts
@@ -144,6 +144,19 @@ export function useInstallSoftware() {
   });
 }
 
+export function useReinstallSoftware() {
+  const queryClient = useQueryClient();
+  const onError = useMutationErrorHandler("Reinstall");
+  return useMutation({
+    mutationFn: (id: string) => { logMutation("reinstall_software", id); return invoke<OperationId>("reinstall_software", { id }); },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["software"] });
+      queryClient.invalidateQueries({ queryKey: ["activity"] });
+    },
+    onError,
+  });
+}
+
 export function useUpdateSoftware() {
   const queryClient = useQueryClient();
   const onError = useMutationErrorHandler("Update");

--- a/frontend/src/views/InstalledView.vue
+++ b/frontend/src/views/InstalledView.vue
@@ -8,7 +8,7 @@ import Button from "primevue/button";
 import PackageRow from "../components/installed/PackageRow.vue";
 import ConfirmDialog from "../components/shared/ConfirmDialog.vue";
 import EmptyState from "../components/shared/EmptyState.vue";
-import { useSoftwareList, useInstallSoftware, useUpdateSoftware, useScanInstalled, useCreateBackup } from "../composables/useInvoke";
+import { useSoftwareList, useReinstallSoftware, useUpdateSoftware, useScanInstalled, useCreateBackup } from "../composables/useInvoke";
 import { useOperations } from "../composables/useOperations";
 import { useUpdateQueue } from "../composables/useUpdateQueue";
 import { FEATURE_BACKUP } from "../features";
@@ -16,7 +16,7 @@ import type { PackageWithStatus } from "../types/package";
 
 const router = useRouter();
 const { data: software, isLoading } = useSoftwareList(() => "installed");
-const installMutation = useInstallSoftware();
+const reinstallMutation = useReinstallSoftware();
 const updateMutation = useUpdateSoftware();
 const scanMutation = useScanInstalled();
 const backupMutation = useCreateBackup();
@@ -79,7 +79,7 @@ function handleReinstall(pkg: PackageWithStatus) {
 function confirmReinstall() {
   const pkg = pendingReinstallPkg.value;
   if (!pkg || !startOperation(pkg.id, `Reinstalling ${pkg.name}`)) return;
-  installMutation.mutate(pkg.id);
+  reinstallMutation.mutate(pkg.id);
   pendingReinstallPkg.value = null;
 }
 

--- a/frontend/src/views/PackageDetailView.vue
+++ b/frontend/src/views/PackageDetailView.vue
@@ -14,7 +14,7 @@ import BackupTab from "../components/detail/BackupTab.vue";
 import TechnicalTab from "../components/detail/TechnicalTab.vue";
 import ConfirmDialog from "../components/shared/ConfirmDialog.vue";
 import EmptyState from "../components/shared/EmptyState.vue";
-import { useSoftwareList, useVersions, useInstallSoftware, useUpdateSoftware, useCreateBackup } from "../composables/useInvoke";
+import { useSoftwareList, useVersions, useInstallSoftware, useReinstallSoftware, useUpdateSoftware, useCreateBackup } from "../composables/useInvoke";
 import { useOperations } from "../composables/useOperations";
 import { useUpdateQueue } from "../composables/useUpdateQueue";
 import { logger } from "../utils/logger";
@@ -28,6 +28,7 @@ const router = useRouter();
 const { data: software, isLoading } = useSoftwareList(() => "all");
 const { data: versions } = useVersions(() => props.id);
 const installMutation = useInstallSoftware();
+const reinstallMutation = useReinstallSoftware();
 const updateMutation = useUpdateSoftware();
 const backupMutation = useCreateBackup();
 const { isRunning } = useOperations();
@@ -70,7 +71,7 @@ function handleReinstall() {
 function confirmReinstall() {
   if (!pkg.value) return;
   logger.debug("PackageDetailView", `reinstall confirmed: ${pkg.value.id}`);
-  installMutation.mutate(pkg.value.id);
+  reinstallMutation.mutate(pkg.value.id);
 }
 
 function handleBackup() {


### PR DESCRIPTION
## Summary
- Add `force_reinstall: bool` to `UpdateRequest` — when true, planner promotes `UpToDate` packages to install instead of skipping
- New `reinstall_software` Tauri command passes `force_reinstall: true`
- Frontend `useReinstallSoftware()` mutation wired to reinstall buttons in detail and installed views

Fixes #989

## Test plan
- [ ] 2 new planner tests: force promotes up-to-date, only affects requested packages
- [ ] Click Reinstall on up-to-date package — verify installer runs
- [ ] Regular install/update still skips up-to-date packages (no regression)
