### PR TITLE
fix: hide main window on startup when start_minimized is enabled

### DIFF
--- a/crates/astro-up-gui/src/lib.rs
+++ b/crates/astro-up-gui/src/lib.rs
@@ -420,6 +420,21 @@ pub fn run() {
                 );
             }
 
+            // Hide window on startup if start_minimized is enabled (#991)
+            {
+                let state = app.state::<AppState>();
+                let start_minimized = state.config.lock().startup.start_minimized;
+                if start_minimized {
+                    if let Some(window) = app.get_webview_window("main") {
+                        if let Err(e) = window.hide() {
+                            tracing::warn!("Failed to hide window on start_minimized: {e}");
+                        } else {
+                            tracing::info!("Window hidden on startup (start_minimized enabled)");
+                        }
+                    }
+                }
+            }
+
             // Startup catalog sync — fetch if missing or stale
             let catalog_handle = app.handle().clone();
             tauri::async_runtime::spawn(async move {


### PR DESCRIPTION
## Summary
- Check `config.startup.start_minimized` after tray setup in lib.rs
- If enabled, call `window.hide()` so app starts in system tray
- Placed after tray/autostart setup, before background tasks

Fixes #991

## Test plan
- [ ] Enable "Start minimized" in settings, restart app — verify window hidden, tray icon visible
- [ ] Disable setting, restart — verify window shows normally
