### PR TITLE
chore: remove unused auto_install_updates and telemetry config fields

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.24"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/crates/astro-up-core/src/config/defaults.rs
+++ b/crates/astro-up-core/src/config/defaults.rs
@@ -19,7 +19,6 @@ impl Default for UiConfig {
             auto_check_updates: true,
             check_interval: Duration::from_secs(86400), // 24h
             auto_notify_updates: true,
-            auto_install_updates: false,
             survey_threshold: 3,
             survey_dismissed_at: None,
             survey_completed_at: None,
@@ -107,5 +106,4 @@ impl Default for LogConfig {
     }
 }
 
-// TelemetryConfig: all fields are false — use #[derive(Default)] on the struct
 // AppConfig: all fields are Default — use #[derive(Default)] on the struct

--- a/crates/astro-up-core/src/config/mod.rs
+++ b/crates/astro-up-core/src/config/mod.rs
@@ -16,7 +16,7 @@ pub use api::{config_get, config_list, config_reset, config_set};
 pub use model::{
     AppConfig, BackupPolicyConfig, BackupSchedule, CatalogConfig, FontSize, InstallMethod,
     InstallScope, LogConfig, LogLevel, NetworkConfig, NotificationsConfig, PathsConfig,
-    ScanInterval, StartupConfig, TelemetryConfig, ThemeMode, UiConfig, UpdateConfig,
+    ScanInterval, StartupConfig, ThemeMode, UiConfig, UpdateConfig,
 };
 pub use store::ConfigStore;
 
@@ -184,11 +184,6 @@ pub(crate) fn set_field(config: &mut AppConfig, key: &str, value: &str) -> Resul
                 .parse::<bool>()
                 .map_err(|_| parse_err("boolean (true/false)"))?;
         }
-        "ui.auto_install_updates" => {
-            config.ui.auto_install_updates = value
-                .parse::<bool>()
-                .map_err(|_| parse_err("boolean (true/false)"))?;
-        }
         "ui.survey_threshold" => {
             config.ui.survey_threshold = value
                 .parse::<u32>()
@@ -344,11 +339,6 @@ pub(crate) fn set_field(config: &mut AppConfig, key: &str, value: &str) -> Resul
                 .parse::<u32>()
                 .map_err(|_| parse_err("number (days, 0 = never)"))?;
         }
-        "telemetry.enabled" => {
-            config.telemetry.enabled = value
-                .parse::<bool>()
-                .map_err(|_| parse_err("boolean (true/false)"))?;
-        }
         _ => {
             return Err(CoreError::ConfigUnknownKey {
                 key: key.to_string(),
@@ -419,7 +409,6 @@ pub(crate) fn get_field_value(config: &AppConfig, key: &str) -> Option<String> {
             Some(humantime::format_duration(config.ui.check_interval).to_string())
         }
         "ui.auto_notify_updates" => Some(config.ui.auto_notify_updates.to_string()),
-        "ui.auto_install_updates" => Some(config.ui.auto_install_updates.to_string()),
         "ui.survey_threshold" => Some(config.ui.survey_threshold.to_string()),
         "ui.survey_dismissed_at" => config.ui.survey_dismissed_at.clone(),
         "ui.survey_completed_at" => config.ui.survey_completed_at.clone(),
@@ -483,7 +472,6 @@ pub(crate) fn get_field_value(config: &AppConfig, key: &str) -> Option<String> {
         "logging.log_to_file" => Some(config.logging.log_to_file.to_string()),
         "logging.log_file" => Some(config.logging.log_file.display().to_string()),
         "logging.max_age_days" => Some(config.logging.max_age_days.to_string()),
-        "telemetry.enabled" => Some(config.telemetry.enabled.to_string()),
         _ => None,
     }
 }

--- a/crates/astro-up-core/src/config/model.rs
+++ b/crates/astro-up-core/src/config/model.rs
@@ -142,7 +142,6 @@ pub struct UiConfig {
     #[garde(custom(validate_min_one_minute))]
     pub check_interval: Duration,
     pub auto_notify_updates: bool,
-    pub auto_install_updates: bool,
     /// Number of successful operations before showing the feedback survey.
     #[serde(default = "default_survey_threshold")]
     pub survey_threshold: u32,
@@ -251,12 +250,6 @@ fn default_log_max_age_days() -> u32 {
 }
 
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Validate)]
-#[garde(allow_unvalidated)]
-pub struct TelemetryConfig {
-    pub enabled: bool,
-}
-
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, Validate)]
 pub struct AppConfig {
     #[garde(dive)]
     pub ui: UiConfig,
@@ -276,8 +269,6 @@ pub struct AppConfig {
     pub updates: UpdateConfig,
     #[garde(dive)]
     pub logging: LogConfig,
-    #[garde(dive)]
-    pub telemetry: TelemetryConfig,
 }
 
 impl AppConfig {

--- a/crates/astro-up-core/tests/config/defaults_test.rs
+++ b/crates/astro-up-core/tests/config/defaults_test.rs
@@ -32,8 +32,6 @@ fn load_config_with_empty_db_returns_defaults() {
     assert_eq!(config.logging.level.to_string(), "info");
     assert!(!config.logging.log_to_file);
     assert_eq!(config.logging.log_file, log_file);
-    assert!(!config.telemetry.enabled);
-
     // Snapshot the config shape (excluding platform-dependent paths)
     let mut value = serde_json::to_value(&config).unwrap();
     // Redact platform-dependent paths for stable snapshots
@@ -79,6 +77,5 @@ fn known_keys_discovers_all_fields() {
     assert!(keys.contains(&"catalog.url".to_string()));
     assert!(keys.contains(&"network.timeout".to_string()));
     assert!(keys.contains(&"logging.level".to_string()));
-    assert!(keys.contains(&"telemetry.enabled".to_string()));
-    assert_eq!(keys.len(), 46);
+    assert_eq!(keys.len(), 44);
 }

--- a/crates/astro-up-core/tests/config/edge_cases_test.rs
+++ b/crates/astro-up-core/tests/config/edge_cases_test.rs
@@ -65,7 +65,7 @@ fn config_list_empty_db_returns_all_defaults() {
     let config = load_config(&db_path, paths, log_file, &[]).unwrap();
 
     let list = config_list(&config, &[]);
-    assert_eq!(list.len(), 46);
+    assert_eq!(list.len(), 44);
     assert!(list.iter().all(|(_, _, overridden)| !overridden));
 }
 

--- a/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
+++ b/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
@@ -47,12 +47,8 @@ expression: value
     "start_at_login": false,
     "start_minimized": false
   },
-  "telemetry": {
-    "enabled": false
-  },
   "ui": {
     "auto_check_updates": true,
-    "auto_install_updates": false,
     "auto_notify_updates": true,
     "auto_scan_on_launch": false,
     "check_interval": "1day",

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -21,7 +21,6 @@ default_install_method = "silent"
 auto_check_updates = true
 check_interval = "12h"
 auto_notify_updates = true
-auto_install_updates = false
 
 [catalog]
 url = "https://github.com/nightwatch-astro/astro-up-manifests/releases/latest/download/catalog.db"
@@ -78,7 +77,6 @@ Every field below has a corresponding control in the GUI Settings panel. The tab
 | `auto_check_updates` | bool | `true` | General | Periodically check for package updates |
 | `check_interval` | duration | `"12h"` | General | How often to check for updates |
 | `auto_notify_updates` | bool | `true` | General | Show notification when updates found |
-| `auto_install_updates` | bool | `false` | General | Automatically install updates |
 
 ### `[catalog]`
 

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -79,4 +79,3 @@ export interface LogConfig {
   log_file: string;
   max_age_days: number;
 }
-

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -8,7 +8,6 @@ export interface AppConfig {
   network: NetworkConfig;
   updates: UpdateConfig;
   logging: LogConfig;
-  telemetry: TelemetryConfig;
 }
 
 export type ScanInterval = "manual" | "on_startup" | "hourly" | "daily" | "weekly";
@@ -23,7 +22,6 @@ export interface UiConfig {
   auto_check_updates: boolean;
   check_interval: string;
   auto_notify_updates: boolean;
-  auto_install_updates: boolean;
 }
 
 export interface StartupConfig {
@@ -82,6 +80,3 @@ export interface LogConfig {
   max_age_days: number;
 }
 
-export interface TelemetryConfig {
-  enabled: boolean;
-}

--- a/frontend/src/validation/config.ts
+++ b/frontend/src/validation/config.ts
@@ -10,7 +10,6 @@ export const UiSchema = v.object({
   auto_check_updates: v.boolean(),
   check_interval: v.pipe(v.string(), v.minLength(1, "Required")),
   auto_notify_updates: v.boolean(),
-  auto_install_updates: v.boolean(),
 });
 
 export const StartupSchema = v.object({
@@ -68,10 +67,6 @@ export const UpdateSchema = v.object({
   check_interval: v.pipe(v.string(), v.minLength(1, "Required")),
 });
 
-export const TelemetrySchema = v.object({
-  enabled: v.boolean(),
-});
-
 export const AppConfigSchema = v.object({
   ui: UiSchema,
   startup: StartupSchema,
@@ -82,5 +77,4 @@ export const AppConfigSchema = v.object({
   network: NetworkSchema,
   updates: UpdateSchema,
   logging: LogSchema,
-  telemetry: TelemetrySchema,
 });

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -43,9 +43,9 @@ const defaultConfig: AppConfig = {
   ui: {
     theme: "system", font_size: "medium", auto_scan_on_launch: true,
     scan_interval: "on_startup",
-    default_install_scope: "user", default_install_method: "silent",
+    default_install_scope: "user", default_install_method: "interactive",
     auto_check_updates: true, check_interval: "1day",
-    auto_notify_updates: true, auto_install_updates: false,
+    auto_notify_updates: true,
   },
   startup: { start_at_login: true, start_minimized: true, minimize_to_tray_on_close: true },
   notifications: {
@@ -59,7 +59,6 @@ const defaultConfig: AppConfig = {
   paths: { download_dir: "", cache_dir: "", data_dir: "", keep_installers: false, purge_installers_after_days: 7 },
   updates: { auto_check: true, check_interval: "1day" },
   logging: { level: "info", log_to_file: true, log_file: "", max_age_days: 365 },
-  telemetry: { enabled: false },
 };
 
 const config = reactive<AppConfig>(structuredClone(defaultConfig));


### PR DESCRIPTION
## Summary
- Remove `auto_install_updates` from UiConfig (UI toggle already removed in PR #962, field was dead code)
- Remove `TelemetryConfig` struct and `telemetry` field from AppConfig (no UI, no backend usage)
- Cleaned up: model, defaults, config set/get, tests, snapshots, docs, frontend types/validation

Fixes #993, fixes #994

## Test plan
- [ ] All 28 config tests pass
- [ ] Existing DBs with these fields load without error (merge_overrides_lenient handles unknown keys)
