### PR TITLE
perf(ci): use cargo-binstall for tauri-cli in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,8 +94,11 @@ jobs:
           cp target/x86_64-pc-windows-msvc/release/astro-up-cli.exe \
              crates/astro-up-gui/binaries/astro-up-cli-x86_64-pc-windows-msvc.exe
 
+      - name: Install cargo-binstall
+        run: curl -L --proto '=https' --tlsv1.2 -sSf https://raw.githubusercontent.com/cargo-bins/cargo-binstall/main/install-from-binstall-release.sh | bash
+
       - name: Install Tauri CLI
-        run: cargo install tauri-cli --version ^2 --locked
+        run: cargo binstall tauri-cli --version ^2 --no-confirm
 
       - name: Build Tauri app
         uses: tauri-apps/tauri-action@v0


### PR DESCRIPTION
## Summary
Use `cargo binstall` instead of `cargo install` for tauri-cli in the release workflow. Downloads a pre-built binary instead of compiling from source — saves several minutes on each release build.

## Test plan
- [ ] Next release build uses binstall and completes faster
