### PR TITLE
fix: remove duplicate SurveyDialog causing dismiss to not stick

### DIFF
--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -237,9 +237,6 @@ function confirmSingleUpdate() {
       @confirm="confirmSingleUpdate"
     />
 
-    <SurveyDialog
-      v-model:visible="showSurvey"
-    />
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
Remove duplicate `SurveyDialog` in DashboardView — two instances were bound to the same `showSurvey` ref, causing the dismiss (X button) to race between dialogs. The second instance re-triggers while the first is closing.

## Test plan
- [ ] Open dashboard, see survey prompt, click X — verify it stays dismissed
- [ ] Navigate away and back — verify survey does not reappear (30-day snooze)
