### PR TITLE
fix: try fallback when primary detection returns unknown version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.24"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.23"
+version = "0.1.24"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/crates/astro-up-core/src/detect/mod.rs
+++ b/crates/astro-up-core/src/detect/mod.rs
@@ -127,12 +127,32 @@ pub async fn run_chain(
             );
             result
         }
-        DetectionResult::InstalledUnknownVersion { method, .. } => {
+        DetectionResult::InstalledUnknownVersion {
+            method,
+            install_path,
+        } => {
+            // Try fallback to get an actual version — a versioned result is
+            // strictly better than unknown-version.
+            if let Some(next) = &config.fallback {
+                tracing::debug!(
+                    method = %method,
+                    next_method = %next.method,
+                    "detection chain: installed (unknown version), trying fallback for version"
+                );
+                let fallback_result =
+                    Box::pin(run_chain(next, resolver, ledger_path, wmi_ctx)).await;
+                if matches!(&fallback_result, DetectionResult::Installed { .. }) {
+                    return fallback_result;
+                }
+            }
             tracing::debug!(
                 method = %method,
-                "detection chain: installed (unknown version)"
+                "detection chain: installed (unknown version, no better result from fallback)"
             );
-            result
+            DetectionResult::InstalledUnknownVersion {
+                method: method.clone(),
+                install_path: install_path.clone(),
+            }
         }
         DetectionResult::NotInstalled => match &config.fallback {
             Some(next) => {

--- a/frontend/src/components/catalog/PackageCard.vue
+++ b/frontend/src/components/catalog/PackageCard.vue
@@ -60,11 +60,11 @@ const categoryClass: Record<Category, string> = {
       <div class="sw-status">
         <template v-if="pkg.update_available">
           <span class="status-dot update" />
-          <span class="status-update">{{ pkg.installed_version }} &rarr; {{ pkg.latest_version }}</span>
+          <span class="status-update">{{ pkg.installed_version === "0.0.0" ? "unknown" : pkg.installed_version }} &rarr; {{ pkg.latest_version }}</span>
         </template>
         <template v-else-if="pkg.installed_version">
           <span class="status-dot installed" />
-          <span class="status-installed">{{ pkg.installed_version }}</span>
+          <span class="status-installed">{{ pkg.installed_version === "0.0.0" ? "unknown" : pkg.installed_version }}</span>
         </template>
         <template v-else>
           <span class="status-dot none" />

--- a/frontend/src/components/detail/OverviewTab.vue
+++ b/frontend/src/components/detail/OverviewTab.vue
@@ -23,7 +23,7 @@ function detectionMethod(pkg: PackageWithStatus): string {
       class="info-item"
     >
       <span class="info-label">Installed Version</span>
-      <span class="info-value">{{ pkg.installed_version }}</span>
+      <span class="info-value">{{ pkg.installed_version === "0.0.0" ? "unknown" : pkg.installed_version }}</span>
     </div>
     <div
       v-if="pkg.latest_version"

--- a/frontend/src/components/installed/PackageRow.vue
+++ b/frontend/src/components/installed/PackageRow.vue
@@ -37,11 +37,11 @@ defineEmits<{
     </div>
     <div class="inst-version">
       <template v-if="pkg.update_available">
-        <span class="ver-update">{{ pkg.installed_version }} &rarr; {{ pkg.latest_version }}</span>
+        <span class="ver-update">{{ pkg.installed_version === "0.0.0" ? "unknown" : pkg.installed_version }} &rarr; {{ pkg.latest_version }}</span>
       </template>
       <template v-else>
         <span class="ver-ok">
-          {{ pkg.installed_version }}
+          {{ pkg.installed_version === "0.0.0" ? "unknown" : pkg.installed_version }}
           <i class="pi pi-check" />
         </span>
       </template>

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -171,7 +171,7 @@ function confirmSingleUpdate() {
             </div>
           </div>
           <div class="upd-arrow">
-            {{ pkg.installed_version }} &rarr; {{ pkg.latest_version }}
+            {{ pkg.installed_version === "0.0.0" ? "unknown" : pkg.installed_version }} &rarr; {{ pkg.latest_version }}
           </div>
           <Button
             label="Update"

--- a/frontend/src/views/InstalledView.vue
+++ b/frontend/src/views/InstalledView.vue
@@ -175,7 +175,7 @@ function handleBackup(pkg: PackageWithStatus) {
     <ConfirmDialog
       v-model:visible="showUpdateConfirm"
       title="Update Package"
-      :message="`Update ${pendingUpdatePkg?.name} from ${pendingUpdatePkg?.installed_version} to ${pendingUpdatePkg?.latest_version}?`"
+      :message="`Update ${pendingUpdatePkg?.name} from ${pendingUpdatePkg?.installed_version === '0.0.0' ? 'unknown' : pendingUpdatePkg?.installed_version} to ${pendingUpdatePkg?.latest_version}?`"
       icon="pi-arrow-up"
       confirm-label="Update"
       severity="warn"
@@ -196,7 +196,7 @@ function handleBackup(pkg: PackageWithStatus) {
           v-for="pkg in updatable"
           :key="pkg.id"
         >
-          {{ pkg.name }}: {{ pkg.installed_version }} &rarr; {{ pkg.latest_version }}
+          {{ pkg.name }}: {{ pkg.installed_version === "0.0.0" ? "unknown" : pkg.installed_version }} &rarr; {{ pkg.latest_version }}
         </li>
       </ul>
     </ConfirmDialog>


### PR DESCRIPTION
## Summary
- Detection chain now tries fallback when primary returns `InstalledUnknownVersion` — if the fallback finds an actual version, it's used instead
- Previously, `InstalledUnknownVersion` was treated as "found" and the chain stopped, never trying PE file/file_exists fallbacks that could provide a real version
- This caused packages like ASTAP (registry key exists, no DisplayVersion) to permanently show as `0.0.0` in the ledger even when a PE file fallback was available
- Also displays "unknown" instead of "0.0.0" in the Installed view for sentinel versions

## Root Cause
`run_chain()` stopped at `InstalledUnknownVersion` without trying the fallback. After the manifest fallback fix (astro-up-manifests#174), the catalog has correct `fallback_config` but it was never reached.

## Test plan
- [ ] Scan on .111 — verify ASTAP shows actual version from PE file instead of `0.0.0`
- [ ] Packages without fallback still show "unknown" (not `0.0.0`)
- [ ] Detection chain still stops at `Installed` (with version) — no unnecessary fallback attempts
