### PR TITLE
feat: portable apps folder for download-only packages

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,8 +70,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
-        with:
-          version: latest
       - uses: actions/setup-node@v6.3.0
         with:
           node-version: 22

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,6 +70,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: pnpm/action-setup@v6
+        with:
+          package_json_file: frontend/package.json
       - uses: actions/setup-node@v6.3.0
         with:
           node-version: 22

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -146,6 +146,8 @@ PR titles become changelog entries via squash merge. The release-please draft PR
 - SQLite (existing — catalog + config via astro-up-core, rusqlite 0.39) (016-tauri-app-shell)
 - Rust 2024 edition (1.85+), TypeScript 5, Vue 3 + racing 0.1, tracing-subscriber 0.3 (fmt, json, env-filter), tracing-appender 0.2, PrimeVue 4 (toast), @tanstack/vue-query 5 (027-logging-debugging)
 - N/A (no new storage — logging is file/stderr/LogPanel) (027-logging-debugging)
+- Rust 2024 edition + Vue 3 / TypeScript 5 + okio (async fs), zip 2 (extraction), directories 6.0 (platform paths) (031-portable-apps-folder)
+- SQLite (config_settings, ledger tables — existing) (031-portable-apps-folder)
 
 - Vue 3 + vue-router 4 (hash mode), PrimeVue 4 (Aura), @tanstack/vue-query 5, @vueuse/core 14, valibot 1, TypeScript 5 (022-vue-frontend)
 - localStorage for config snapshots, mock data layer for stubbed Tauri commands (022-vue-frontend)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "async-signal"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c070bbf59cd3570b6b2dd54cd772527c7c3620fce8be898406dd3ed6adc64c"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
 dependencies = [
  "async-io",
  "async-lock",
@@ -708,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.59"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7a4d3ec6524d28a329fc53654bbadc9bdd7b0431f5d65f1a56ffb28a1ee5283"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -965,7 +965,7 @@ dependencies = [
  "cookie",
  "document-features",
  "idna",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -1681,9 +1681,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
-version = "2.4.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a043dc74da1e37d6afe657061213aa6f425f855399a11d3463c6ecccc4dfda1f"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fd-lock"
@@ -2293,7 +2293,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -2329,6 +2329,12 @@ checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -2504,15 +2510,14 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "c2b52f86d1d4bc0d6b4e6826d960b1b333217e07d36b882dca570a5e1c48895b"
 dependencies = [
  "http",
  "hyper",
  "hyper-util",
  "rustls",
- "rustls-pki-types",
  "tokio",
  "tokio-rustls",
  "tower-service",
@@ -2709,12 +2714,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.1"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45a8a2b9cb3e0b0c1803dbb0758ffac5de2f425b23c28f518faabd9d805342ff"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "serde",
  "serde_core",
 ]
@@ -2764,7 +2769,7 @@ dependencies = [
  "serde",
  "similar",
  "tempfile",
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
  "toml_writer",
 ]
 
@@ -2894,9 +2899,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e04e2ef80ce82e13552136fabeef8a5ed1f985a96805761cbb9a2c34e7664d9"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -2945,7 +2950,7 @@ checksum = "02cb977175687f33fa4afa0c95c112b987ea1443e5a51c8f8ff27dc618270cc2"
 dependencies = [
  "cssparser 0.29.6",
  "html5ever 0.29.1",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "selectors 0.24.0",
 ]
 
@@ -3009,14 +3014,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.15"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ddbf48fd451246b1f8c2610bd3b4ac0cc6e149d89832867093ab69a17194f08"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
  "bitflags 2.11.0",
  "libc",
  "plain",
- "redox_syscall 0.7.3",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -3920,9 +3925,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -3937,7 +3942,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
 dependencies = [
  "base64 0.22.1",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "quick-xml",
  "serde",
  "time",
@@ -4088,7 +4093,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.10+spec-1.1.0",
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -4191,7 +4196,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -4265,9 +4270,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4365,9 +4370,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.3"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce70a74e890531977d37e532c34d45e9055d2409ed08ddba14529471ed0be16"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags 2.11.0",
 ]
@@ -4619,9 +4624,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -4684,9 +4689,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.10"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df33b2b81ac578cabaf06b89b0631153a3f416b0a886e8a7a1707fb51abbd1ef"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -4990,7 +4995,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "schemars 0.9.0",
  "schemars 1.2.1",
  "serde_core",
@@ -6153,7 +6158,7 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
@@ -6168,7 +6173,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6210,7 +6215,7 @@ version = "0.19.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "toml_datetime 0.6.3",
  "winnow 0.5.40",
 ]
@@ -6221,7 +6226,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.3",
@@ -6230,11 +6235,11 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.10+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a82418ca169e235e6c399a84e395ab6debeb3bc90edc959bf0f48647c6a32d1b"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 1.1.1+spec-1.1.0",
@@ -6749,9 +6754,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0551fc1bb415591e3372d0bc4780db7e587d84e2a7e79da121051c5c4b89d0b0"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -6762,9 +6767,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.67"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03623de6905b7206edd0a75f69f747f134b7f0a2323392d664448bf2d3c5d87e"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6772,9 +6777,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fbdf9a35adf44786aecd5ff89b4563a90325f9da0923236f6104e603c7e86be"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6782,9 +6787,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca9693ef2bab6d4e6707234500350d8dad079eb508dca05530c85dc3a529ff2"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -6795,9 +6800,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.117"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39129a682a6d2d841b6c429d0c51e5cb0ed1a03829d8b3d1e69a011e62cb3d3b"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -6819,7 +6824,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -6845,15 +6850,15 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.0",
  "hashbrown 0.15.5",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "semver",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.94"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd70027e39b12f0849461e08ffc50b9cd7688d942c1c8e3c7b22273236b4dd0a"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -7571,7 +7576,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck 0.5.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn 2.0.117",
  "wasm-metadata",
@@ -7602,7 +7607,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.0",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -7621,7 +7626,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -7919,7 +7924,7 @@ checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
 dependencies = [
  "arbitrary",
  "crc32fast",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "memchr",
 ]
 
@@ -7938,7 +7943,7 @@ dependencies = [
  "flate2",
  "getrandom 0.3.4",
  "hmac",
- "indexmap 2.13.1",
+ "indexmap 2.14.0",
  "lzma-rust2",
  "memchr",
  "pbkdf2",

--- a/_typos.toml
+++ b/_typos.toml
@@ -2,3 +2,8 @@
 ratatui = "ratatui"
 Pn = "Pn"
 flate = "flate"
+# Git commit hash fragments in CHANGELOG.md
+ba = "ba"
+
+[files]
+extend-exclude = ["CHANGELOG.md"]

--- a/crates/astro-up-cli/src/commands/install.rs
+++ b/crates/astro-up-cli/src/commands/install.rs
@@ -132,6 +132,14 @@ pub async fn handle_install(
         force_reinstall: false,
         quiet,
         install_scope: state.config.ui.default_install_scope.clone(),
+        portable_apps_dir: {
+            let dir = &state.config.paths.portable_apps_dir;
+            if dir.as_os_str().is_empty() {
+                None
+            } else {
+                Some(dir.clone())
+            }
+        },
     };
 
     let orch_plan = orchestrator

--- a/crates/astro-up-cli/src/commands/update.rs
+++ b/crates/astro-up-cli/src/commands/update.rs
@@ -99,6 +99,14 @@ pub async fn handle_update(
         force_reinstall: false,
         quiet,
         install_scope: state.config.ui.default_install_scope.clone(),
+        portable_apps_dir: {
+            let dir = &state.config.paths.portable_apps_dir;
+            if dir.as_os_str().is_empty() {
+                None
+            } else {
+                Some(dir.clone())
+            }
+        },
     };
 
     let plan = orchestrator

--- a/crates/astro-up-core/src/config/defaults.rs
+++ b/crates/astro-up-core/src/config/defaults.rs
@@ -68,6 +68,7 @@ impl Default for PathsConfig {
             download_dir: PathBuf::default(),
             cache_dir: PathBuf::default(),
             data_dir: PathBuf::default(),
+            portable_apps_dir: PathBuf::default(),
             keep_installers: true,
             purge_installers_after_days: 30,
         }

--- a/crates/astro-up-core/src/config/mod.rs
+++ b/crates/astro-up-core/src/config/mod.rs
@@ -284,6 +284,7 @@ pub(crate) fn set_field(config: &mut AppConfig, key: &str, value: &str) -> Resul
         "paths.download_dir" => config.paths.download_dir = PathBuf::from(value),
         "paths.cache_dir" => config.paths.cache_dir = PathBuf::from(value),
         "paths.data_dir" => config.paths.data_dir = PathBuf::from(value),
+        "paths.portable_apps_dir" => config.paths.portable_apps_dir = PathBuf::from(value),
         "paths.keep_installers" => {
             config.paths.keep_installers = value
                 .parse::<bool>()
@@ -447,6 +448,7 @@ pub(crate) fn get_field_value(config: &AppConfig, key: &str) -> Option<String> {
         "paths.download_dir" => Some(config.paths.download_dir.display().to_string()),
         "paths.cache_dir" => Some(config.paths.cache_dir.display().to_string()),
         "paths.data_dir" => Some(config.paths.data_dir.display().to_string()),
+        "paths.portable_apps_dir" => Some(config.paths.portable_apps_dir.display().to_string()),
         "paths.keep_installers" => Some(config.paths.keep_installers.to_string()),
         "paths.purge_installers_after_days" => {
             Some(config.paths.purge_installers_after_days.to_string())

--- a/crates/astro-up-core/src/config/model.rs
+++ b/crates/astro-up-core/src/config/model.rs
@@ -205,6 +205,7 @@ pub struct PathsConfig {
     pub download_dir: PathBuf,
     pub cache_dir: PathBuf,
     pub data_dir: PathBuf,
+    pub portable_apps_dir: PathBuf,
     pub keep_installers: bool,
     pub purge_installers_after_days: u32,
 }

--- a/crates/astro-up-core/src/engine/orchestrator.rs
+++ b/crates/astro-up-core/src/engine/orchestrator.rs
@@ -63,6 +63,11 @@ pub struct UpdateRequest {
     /// Install scope: user or machine.
     #[serde(default)]
     pub install_scope: crate::config::InstallScope,
+    /// Directory for portable/download-only packages.
+    /// When set, DownloadOnly and Portable packages are installed to
+    /// `{portable_apps_dir}/{package-id}/` instead of a temp directory.
+    #[serde(default)]
+    pub portable_apps_dir: Option<std::path::PathBuf>,
 }
 
 pub(crate) fn default_quiet() -> bool {
@@ -279,6 +284,7 @@ where
         cancel: &CancellationToken,
         quiet: bool,
         install_scope: &crate::config::InstallScope,
+        portable_apps_dir: &Option<std::path::PathBuf>,
     ) -> PackageResult {
         use std::time::Instant;
 
@@ -516,12 +522,24 @@ where
             .timeout
             .unwrap_or(std::time::Duration::from_secs(600));
 
+        // For DownloadOnly/Portable packages, set install_dir to portable apps dir
+        let install_dir = if matches!(
+            install_config.method,
+            crate::types::InstallMethod::DownloadOnly | crate::types::InstallMethod::Portable
+        ) {
+            portable_apps_dir
+                .as_ref()
+                .map(|dir| dir.join(pkg_id.as_ref()))
+        } else {
+            None
+        };
+
         let install_request = crate::install::types::InstallRequest {
             package_id: pkg_id.to_string(),
             package_name: planned.software.name.clone(),
             version: planned.target_version.clone(),
             installer_path,
-            install_dir: None,
+            install_dir,
             install_config,
             detection_config: planned.software.detection.clone(),
             timeout,
@@ -844,6 +862,7 @@ where
         };
         plan.quiet = request.quiet;
         plan.install_scope = request.install_scope;
+        plan.portable_apps_dir = request.portable_apps_dir;
         Ok(plan)
     }
 
@@ -908,6 +927,7 @@ where
                     &cancel,
                     plan.quiet,
                     &plan.install_scope,
+                    &plan.portable_apps_dir,
                 )
                 .await;
 
@@ -1304,6 +1324,7 @@ mod tests {
             force_reinstall: false,
             quiet: false,
             install_scope: crate::config::InstallScope::default(),
+            portable_apps_dir: None,
         };
 
         let json = serde_json::to_string(&req).unwrap();
@@ -1366,6 +1387,7 @@ mod tests {
                 &cancel,
                 true,
                 &crate::config::InstallScope::default(),
+                &None,
             )
             .await;
 
@@ -1409,6 +1431,7 @@ mod tests {
                 &cancel,
                 true,
                 &crate::config::InstallScope::default(),
+                &None,
             )
             .await;
 
@@ -1461,6 +1484,7 @@ mod tests {
             warnings: vec![],
             quiet: true,
             install_scope: crate::config::InstallScope::default(),
+            portable_apps_dir: None,
         };
 
         let result = orch.execute(plan, on_event, None, cancel).await.unwrap();
@@ -1506,6 +1530,7 @@ mod tests {
             warnings: vec![],
             quiet: true,
             install_scope: crate::config::InstallScope::default(),
+            portable_apps_dir: None,
         };
 
         let result = orch.execute(plan, on_event, None, cancel).await.unwrap();
@@ -1549,6 +1574,7 @@ mod tests {
             warnings: vec![],
             quiet: true,
             install_scope: crate::config::InstallScope::default(),
+            portable_apps_dir: None,
         };
 
         let result = orch.execute(plan, on_event, None, cancel).await.unwrap();

--- a/crates/astro-up-core/src/engine/planner.rs
+++ b/crates/astro-up-core/src/engine/planner.rs
@@ -118,6 +118,9 @@ pub struct UpdatePlan {
     /// Install scope: user or machine.
     #[serde(default)]
     pub install_scope: crate::config::InstallScope,
+    /// Directory for portable/download-only packages.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub portable_apps_dir: Option<std::path::PathBuf>,
 }
 
 // ---------------------------------------------------------------------------
@@ -328,6 +331,7 @@ impl UpdatePlanner {
             warnings,
             quiet: false,
             install_scope: crate::config::InstallScope::default(),
+            portable_apps_dir: None,
         })
     }
 
@@ -430,6 +434,7 @@ impl UpdatePlanner {
             warnings,
             quiet: full_plan.quiet,
             install_scope: full_plan.install_scope,
+            portable_apps_dir: full_plan.portable_apps_dir,
         })
     }
 }

--- a/crates/astro-up-core/src/install/mod.rs
+++ b/crates/astro-up-core/src/install/mod.rs
@@ -69,9 +69,9 @@ impl InstallerService {
             debug!("failed to send InstallStarted event: {e}");
         }
 
-        // DownloadOnly: open folder, no execution
+        // DownloadOnly: copy/extract to portable apps dir
         if config.method == InstallMethod::DownloadOnly {
-            let result = self.handle_download_only(&request.installer_path).await;
+            let result = self.handle_download_only(request).await;
             self.record_metrics(&request.package_id, start);
             return result;
         }
@@ -385,23 +385,47 @@ impl InstallerService {
         Ok(InstallResult::Success { path: Some(dest) })
     }
 
-    /// Handles DownloadOnly packages: opens the containing folder on Windows.
-    /// On non-Windows, returns `Success` without opening a folder (no desktop
-    /// environment assumed in CI/cross-compile targets).
+    /// Handles DownloadOnly packages: copies or extracts the download to the
+    /// portable apps directory (`install_dir` on the request).
     ///
-    /// Returns the parent directory of the installer so the UI can show the
-    /// download location to the user.
-    #[allow(unused_variables)]
+    /// If the download is a zip archive (detected via magic bytes), it is extracted.
+    /// Otherwise, the file is copied as-is into the target directory.
+    #[instrument(skip_all, fields(package = %request.package_id))]
     async fn handle_download_only(
         &self,
-        installer_path: &std::path::Path,
+        request: &InstallRequest,
     ) -> Result<InstallResult, CoreError> {
-        let parent = installer_path.parent().map(std::path::Path::to_path_buf);
-        #[cfg(windows)]
-        if let Some(ref dir) = parent {
-            std::process::Command::new("explorer").arg(dir).spawn()?;
+        let dest = self.resolve_install_dir(request);
+
+        // Clean existing contents for in-place updates (FR-009)
+        if dest.exists() {
+            if let Err(e) = tokio::fs::remove_dir_all(&dest).await {
+                warn!(path = %dest.display(), error = %e, "failed to clean existing portable dir");
+            }
         }
-        Ok(InstallResult::Success { path: parent })
+
+        tokio::fs::create_dir_all(&dest).await?;
+
+        // Detect zip by magic bytes (PK\x03\x04)
+        let is_zip = if let Ok(mut f) = tokio::fs::File::open(&request.installer_path).await {
+            use tokio::io::AsyncReadExt;
+            let mut magic = [0u8; 4];
+            f.read_exact(&mut magic).await.is_ok() && magic == [0x50, 0x4B, 0x03, 0x04]
+        } else {
+            false
+        };
+
+        if is_zip {
+            info!(path = %request.installer_path.display(), dest = %dest.display(), "extracting zip to portable dir");
+            zip::extract_zip(&request.installer_path, &dest).await?;
+        } else {
+            let filename = request.installer_path.file_name().unwrap_or_default();
+            let target = dest.join(filename);
+            info!(src = %request.installer_path.display(), dest = %target.display(), "copying file to portable dir");
+            tokio::fs::copy(&request.installer_path, &target).await?;
+        }
+
+        Ok(InstallResult::Success { path: Some(dest) })
     }
 
     #[instrument(skip_all, fields(package = %request.package_id))]

--- a/crates/astro-up-core/tests/config/defaults_test.rs
+++ b/crates/astro-up-core/tests/config/defaults_test.rs
@@ -77,5 +77,5 @@ fn known_keys_discovers_all_fields() {
     assert!(keys.contains(&"catalog.url".to_string()));
     assert!(keys.contains(&"network.timeout".to_string()));
     assert!(keys.contains(&"logging.level".to_string()));
-    assert_eq!(keys.len(), 44);
+    assert_eq!(keys.len(), 45);
 }

--- a/crates/astro-up-core/tests/config/edge_cases_test.rs
+++ b/crates/astro-up-core/tests/config/edge_cases_test.rs
@@ -65,7 +65,7 @@ fn config_list_empty_db_returns_all_defaults() {
     let config = load_config(&db_path, paths, log_file, &[]).unwrap();
 
     let list = config_list(&config, &[]);
-    assert_eq!(list.len(), 44);
+    assert_eq!(list.len(), 45);
     assert!(list.iter().all(|(_, _, overridden)| !overridden));
 }
 

--- a/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
+++ b/crates/astro-up-core/tests/config/snapshots/config_tests__config__defaults_test__default_config.snap
@@ -40,6 +40,7 @@ expression: value
     "data_dir": "[platform_path]",
     "download_dir": "[platform_path]",
     "keep_installers": true,
+    "portable_apps_dir": "",
     "purge_installers_after_days": 30
   },
   "startup": {

--- a/crates/astro-up-core/tests/engine_orchestrator.rs
+++ b/crates/astro-up-core/tests/engine_orchestrator.rs
@@ -337,6 +337,7 @@ async fn single_package_happy_path_events_in_order() {
         warnings: vec![],
         quiet: true,
         install_scope: astro_up_core::config::InstallScope::default(),
+        portable_apps_dir: None,
     };
 
     let result = orch.execute(plan, on_event, None, cancel).await.unwrap();
@@ -430,6 +431,7 @@ async fn process_blocking_emits_event_and_fails() {
         warnings: vec![],
         quiet: true,
         install_scope: astro_up_core::config::InstallScope::default(),
+        portable_apps_dir: None,
     };
 
     let result = orch.execute(plan, on_event, None, cancel).await.unwrap();
@@ -498,6 +500,7 @@ async fn cancellation_mid_pipeline() {
         warnings: vec![],
         quiet: true,
         install_scope: astro_up_core::config::InstallScope::default(),
+        portable_apps_dir: None,
     };
 
     let result = orch.execute(plan, on_event, None, cancel).await.unwrap();
@@ -553,6 +556,7 @@ async fn failure_after_backup_includes_backup_path() {
         warnings: vec![],
         quiet: true,
         install_scope: astro_up_core::config::InstallScope::default(),
+        portable_apps_dir: None,
     };
 
     let result = orch.execute(plan, on_event, None, cancel).await.unwrap();

--- a/crates/astro-up-gui/src/commands.rs
+++ b/crates/astro-up-gui/src/commands.rs
@@ -668,6 +668,14 @@ async fn run_orchestrated_operation_inner(
                     force_reinstall,
                     quiet,
                     install_scope: config.ui.default_install_scope.clone(),
+                    portable_apps_dir: {
+                        let dir = &config.paths.portable_apps_dir;
+                        if dir.as_os_str().is_empty() {
+                            None
+                        } else {
+                            Some(dir.clone())
+                        }
+                    },
                 })
                 .await?;
 

--- a/crates/astro-up-gui/src/log_layer.rs
+++ b/crates/astro-up-gui/src/log_layer.rs
@@ -92,7 +92,7 @@ where
         event.record(&mut visitor);
 
         let entry = LogEntry {
-            timestamp: chrono::Utc::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, true),
+            timestamp: chrono::Local::now().to_rfc3339_opts(chrono::SecondsFormat::Millis, false),
             level: level.to_string().to_lowercase(),
             target: metadata.target().to_string(),
             message: visitor.result(),

--- a/crates/astro-up-gui/src/state.rs
+++ b/crates/astro-up-gui/src/state.rs
@@ -64,6 +64,7 @@ impl AppState {
             download_dir: data_dir.join("downloads"),
             cache_dir: data_dir.join("cache"),
             data_dir: data_dir.to_path_buf(),
+            portable_apps_dir: data_dir.parent().unwrap_or(data_dir).join("apps"),
             ..PathsConfig::default()
         };
         let log_file = data_dir.join("logs").join("astro-up.log");

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.1.0",
   "type": "module",
-  "packageManager": "pnpm@10.28.0",
+  "packageManager": "pnpm@10.33.0",
   "scripts": {
     "dev": "vite",
     "build": "vue-tsc --noEmit && vite build",

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -315,36 +315,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-ZvRYMGrAklV9PEkgt4LQM6MjQX2P58HPAuecwYObY2DhS2t35R0I810bKi0wmaYORt6m/2Sm+Z+nFgb0WhXNcQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-VDpgGBzgfg5hLg+uBpCLoFG5kVvEyafmfxGUV0UHLcL5irxAK7PKNeC2MwClgk6ZAiNhmo9FLhRYgvMmedLtnQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-y1uXY3qQWCzcPgRJATPSOUP4tCemh4uBdY7e3EZbVwCJTY3gLJWnQABgeUetvED+bt1FQ01OeZwvhLS2bpNrAQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.15':
     resolution: {integrity: sha512-023bTPBod7J3Y/4fzAN6QtpkSABR0rigtrwaP+qSEabUh5zf6ELr9Nc7GujaROuPY3uwdSIXWrvhn1KxOvurWA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.15':
     resolution: {integrity: sha512-witB2O0/hU4CgfOOKUoeFgQ4GktPi1eEbAhaLAIpgD6+ZnhcPkUtPsoKKHRzmOoWPZue46IThdSgdo4XneOLYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.15':
     resolution: {integrity: sha512-UCL68NJ0Ud5zRipXZE9dF5PmirzJE4E4BCIOOssEnM7wLDsxjc6Qb0sGDxTNRTP53I6MZpygyCpY8Aa8sPfKPg==}
@@ -1036,24 +1042,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -160,7 +160,7 @@ useCoreEvents((event: CoreEvent) => {
       }
     }
   } else if (event.type === "scan_started") {
-    startOperation("scan", "Scanning installed software");
+    if (!isRunning.value) startOperation("scan", "Scanning installed software");
   } else if (event.type === "scan_complete") {
     completeOperation();
   } else if (event.type === "backup_started" || event.type === "restore_started" || event.type === "install_started") {

--- a/frontend/src/components/detail/OverviewTab.vue
+++ b/frontend/src/components/detail/OverviewTab.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { open as openPath } from "@tauri-apps/plugin-shell";
 import type { PackageWithStatus } from "../../types/package";
 
 defineProps<{
@@ -31,6 +32,22 @@ function detectionMethod(pkg: PackageWithStatus): string {
     >
       <span class="info-label">Latest Version</span>
       <span class="info-value">{{ pkg.latest_version }}</span>
+    </div>
+    <div
+      v-if="pkg.detection?.install_path"
+      class="info-item"
+    >
+      <span class="info-label">Install Location</span>
+      <span class="info-value info-path">
+        {{ pkg.detection.install_path }}
+        <button
+          class="path-open-btn"
+          title="Open folder"
+          @click="openPath(pkg.detection.install_path)"
+        >
+          <i class="pi pi-folder-open" />
+        </button>
+      </span>
     </div>
     <div class="info-item">
       <span class="info-label">Category</span>
@@ -101,5 +118,26 @@ function detectionMethod(pkg: PackageWithStatus): string {
 .info-value {
   font-size: 14px;
   color: var(--p-surface-200);
+}
+
+.info-path {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  word-break: break-all;
+}
+
+.path-open-btn {
+  background: none;
+  border: none;
+  color: var(--p-primary-400);
+  cursor: pointer;
+  padding: 2px;
+  font-size: 14px;
+  flex-shrink: 0;
+}
+
+.path-open-btn:hover {
+  color: var(--p-primary-300);
 }
 </style>

--- a/frontend/src/components/detail/OverviewTab.vue
+++ b/frontend/src/components/detail/OverviewTab.vue
@@ -34,16 +34,16 @@ function detectionMethod(pkg: PackageWithStatus): string {
       <span class="info-value">{{ pkg.latest_version }}</span>
     </div>
     <div
-      v-if="pkg.detection?.install_path"
+      v-if="pkg.detection && 'install_path' in pkg.detection && pkg.detection.install_path"
       class="info-item"
     >
       <span class="info-label">Install Location</span>
       <span class="info-value info-path">
-        {{ pkg.detection.install_path }}
+        {{ (pkg.detection as { install_path: string }).install_path }}
         <button
           class="path-open-btn"
           title="Open folder"
-          @click="openPath(pkg.detection.install_path)"
+          @click="openPath((pkg.detection as { install_path: string }).install_path)"
         >
           <i class="pi pi-folder-open" />
         </button>

--- a/frontend/src/components/detail/OverviewTab.vue
+++ b/frontend/src/components/detail/OverviewTab.vue
@@ -6,6 +6,14 @@ defineProps<{
   pkg: PackageWithStatus;
 }>();
 
+function installPath(pkg: PackageWithStatus): string | null {
+  if (!pkg.detection) return null;
+  if ("install_path" in pkg.detection && pkg.detection.install_path) {
+    return pkg.detection.install_path;
+  }
+  return null;
+}
+
 function detectionMethod(pkg: PackageWithStatus): string {
   if (!pkg.detection) return "Not scanned";
   switch (pkg.detection.type) {
@@ -34,16 +42,16 @@ function detectionMethod(pkg: PackageWithStatus): string {
       <span class="info-value">{{ pkg.latest_version }}</span>
     </div>
     <div
-      v-if="pkg.detection && 'install_path' in pkg.detection && pkg.detection.install_path"
+      v-if="installPath(pkg)"
       class="info-item"
     >
       <span class="info-label">Install Location</span>
       <span class="info-value info-path">
-        {{ (pkg.detection as { install_path: string }).install_path }}
+        {{ installPath(pkg) }}
         <button
           class="path-open-btn"
           title="Open folder"
-          @click="openPath((pkg.detection as { install_path: string }).install_path)"
+          @click="openPath(installPath(pkg)!)"
         >
           <i class="pi pi-folder-open" />
         </button>

--- a/frontend/src/components/layout/AppStatusBar.vue
+++ b/frontend/src/components/layout/AppStatusBar.vue
@@ -1,15 +1,17 @@
 <script setup lang="ts">
 import { computed, onMounted, onUnmounted, ref } from "vue";
 import { listen, type UnlistenFn } from "@tauri-apps/api/event";
-import { useSoftwareList, useUpdateCheck, useCancelOperation } from "../../composables/useInvoke";
+import { useSoftwareList, useCancelOperation } from "../../composables/useInvoke";
 import { useOperations } from "../../composables/useOperations";
+import type { PackageWithStatus } from "../../types/package";
 
 defineEmits<{
   toggleLog: [];
 }>();
 
+// Use the same queries as the dashboard — VueQuery shares the cache
 const { data: software } = useSoftwareList(() => "all");
-const { data: updates } = useUpdateCheck();
+const { data: installedSoftware } = useSoftwareList(() => "installed");
 const { operation, isRunning, cancelOperation } = useOperations();
 const cancelMutation = useCancelOperation();
 
@@ -22,13 +24,11 @@ function handleCancel() {
 }
 
 const catalogCount = computed(() => software.value?.length ?? 0);
-const installedCount = computed(() => {
+const installedCount = computed(() => installedSoftware.value?.length ?? 0);
+const updateCount = computed(() => {
   if (!software.value) return 0;
-  return (software.value as Array<{ detection?: { type: string } }>).filter(
-    (p) => p.detection?.type === "Installed" || p.detection?.type === "InstalledUnknownVersion",
-  ).length;
+  return (software.value as PackageWithStatus[]).filter((p) => p.update_available).length;
 });
-const updateCount = computed(() => updates.value?.length ?? 0);
 
 const lastScanTime = ref<Date | null>(null);
 let unlistenScan: UnlistenFn | null = null;

--- a/frontend/src/components/settings/PathsSection.vue
+++ b/frontend/src/components/settings/PathsSection.vue
@@ -66,6 +66,19 @@ async function browseDirectory(field: keyof PathsConfig) {
         />
       </div>
     </div>
+    <div class="field">
+      <label>Portable Apps Directory</label>
+      <div class="path-row">
+        <code class="path-display">{{ config.portable_apps_dir || "Not set" }}</code>
+        <Button
+          label="Browse"
+          icon="pi pi-folder-open"
+          outlined
+          size="small"
+          @click="browseDirectory('portable_apps_dir')"
+        />
+      </div>
+    </div>
     <div class="field-toggle">
       <ToggleSwitch v-model="config.keep_installers" />
       <label>Keep installers after install</label>

--- a/frontend/src/composables/useOperations.ts
+++ b/frontend/src/composables/useOperations.ts
@@ -15,10 +15,10 @@ export function useOperations() {
       activeOperation.value = null;
     }
 
-    // Safety valve: force-clear stale running operations (>10min)
+    // Safety valve: force-clear stale running operations (>2min)
     if (activeOperation.value && activeOperation.value.status === "running") {
       const started = activeOperation.value.steps[0]?.timestamp;
-      if (started && Date.now() - new Date(started).getTime() > 600_000) {
+      if (started && Date.now() - new Date(started).getTime() > 120_000) {
         logger.debug("useOperations", `force-clearing stale operation: ${activeOperation.value.id}`);
         activeOperation.value = null;
       }

--- a/frontend/src/types/config.ts
+++ b/frontend/src/types/config.ts
@@ -64,6 +64,7 @@ export interface PathsConfig {
   download_dir: string;
   cache_dir: string;
   data_dir: string;
+  portable_apps_dir: string;
   keep_installers: boolean;
   purge_installers_after_days: number;
 }

--- a/frontend/src/validation/config.ts
+++ b/frontend/src/validation/config.ts
@@ -52,6 +52,7 @@ export const PathsSchema = v.object({
   download_dir: v.string(),
   cache_dir: v.string(),
   data_dir: v.optional(v.string()),
+  portable_apps_dir: v.string(),
   keep_installers: v.boolean(),
   purge_installers_after_days: v.pipe(v.number(), v.minValue(0)),
 });

--- a/frontend/src/views/SettingsView.vue
+++ b/frontend/src/views/SettingsView.vue
@@ -56,7 +56,7 @@ const defaultConfig: AppConfig = {
   backup_policy: { scheduled_enabled: false, schedule: "weekly", max_per_package: 5, max_total_size_mb: 0, max_age_days: 0 },
   catalog: { url: "https://github.com/nightwatch-astro/astro-up-manifests/releases/download/catalog/latest/catalog.db", cache_ttl: "1day" },
   network: { proxy: null, connect_timeout: "10s", timeout: "30s", user_agent: "", download_speed_limit: 0 },
-  paths: { download_dir: "", cache_dir: "", data_dir: "", keep_installers: false, purge_installers_after_days: 7 },
+  paths: { download_dir: "", cache_dir: "", data_dir: "", portable_apps_dir: "", keep_installers: false, purge_installers_after_days: 7 },
   updates: { auto_check: true, check_interval: "1day" },
   logging: { level: "info", log_to_file: true, log_file: "", max_age_days: 365 },
 };

--- a/specs/031-portable-apps-folder/checklists/requirements.md
+++ b/specs/031-portable-apps-folder/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Portable Apps Folder
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit.clarify` or `/speckit.plan`.

--- a/specs/031-portable-apps-folder/data-model.md
+++ b/specs/031-portable-apps-folder/data-model.md
@@ -1,0 +1,52 @@
+# Data Model: Portable Apps Folder
+
+## Config: `PathsConfig`
+
+| Field | Type | Default | Storage |
+|-------|------|---------|---------|
+| `portable_apps_dir` | `PathBuf` | `{data_dir}/../apps/` | `config_settings` table, key `paths.portable_apps_dir` |
+
+Existing fields (`download_dir`, `cache_dir`, `data_dir`, `keep_installers`, `purge_installers_after_days`) unchanged.
+
+## Install Pipeline: `InstallRequest`
+
+No new fields. Existing `install_dir: Option<PathBuf>` is populated by the GUI command layer:
+
+| Package Method | `install_dir` value |
+|---------------|-------------------|
+| `DownloadOnly` | `Some({portable_apps_dir}/{package-id})` |
+| `Portable` | `Some({portable_apps_dir}/{package-id})` |
+| All others | `None` (unchanged — installer decides) |
+
+## Ledger: `LedgerEntry`
+
+Existing `install_path: Option<PathBuf>` is populated after successful portable install:
+
+| Scenario | `install_path` value |
+|----------|---------------------|
+| Before this feature (download-only) | Download parent dir or `None` |
+| After this feature (download-only) | `{portable_apps_dir}/{package-id}` |
+| Portable | `{portable_apps_dir}/{package-id}` |
+
+## Frontend: `AppConfig`
+
+```typescript
+interface PathsConfig {
+  download_dir: string;
+  cache_dir: string;
+  data_dir: string;
+  portable_apps_dir: string;  // NEW
+  keep_installers: boolean;
+  purge_installers_after_days: number;
+}
+```
+
+## State Transitions
+
+```
+DownloadOnly package lifecycle:
+  NotInstalled → [Install clicked] → Downloading → Copying/Extracting → Installed
+                                                                         └─ Ledger entry with install_path
+  Installed → [Update clicked] → Downloading → Replacing in-place → Installed (new version)
+  Installed → [Reinstall clicked] → Downloading → Replacing in-place → Installed (same version)
+```

--- a/specs/031-portable-apps-folder/plan.md
+++ b/specs/031-portable-apps-folder/plan.md
@@ -1,0 +1,106 @@
+# Implementation Plan: Portable Apps Folder
+
+**Branch**: `031-portable-apps-folder` | **Date**: 2026-04-12 | **Spec**: [spec.md](spec.md)
+
+## Summary
+
+Add a configurable portable apps directory where `download_only` and `portable` packages are placed. Currently, `download_only` (17 packages) opens Explorer on the download folder. After this change, files are copied/extracted to `{portable_apps_dir}/{package-id}/` with the path recorded in the ledger.
+
+## Technical Context
+
+**Language/Version**: Rust 2024 edition + Vue 3 / TypeScript 5
+**Primary Dependencies**: tokio (async fs), zip 2 (extraction), directories 6.0 (existing — provides data_dir)
+**Storage**: SQLite (config_settings, ledger tables — existing)
+**Testing**: cargo test + vitest
+**Target Platform**: Windows (primary), macOS/Linux (CI compilation)
+**Project Type**: desktop-app (Tauri v2)
+**Performance Goals**: Copy/extract completes within 5 seconds of download finishing
+**Constraints**: No elevation for portable dir (user-owned path)
+**Scale/Scope**: 17 `download_only` manifests, 0 `portable` manifests
+
+## Constitution Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Modules-First | PASS | Changes in existing `install/`, `config/` modules — no new crate |
+| II. Platform Awareness | PASS | Default path uses `directories` crate for platform-appropriate location; `#[cfg(windows)]` for Explorer open |
+| III. Test-First | PASS | Integration tests for copy/extract, snapshot tests for config |
+| IV. Thin Tauri Boundary | PASS | All logic in `astro-up-core`; GUI command passes config path through |
+| V. Spec-Driven | PASS | This spec |
+| VI. Simplicity | PASS | Reuses existing `handle_portable_install` pattern; no new abstractions |
+| VII. Observability | PASS | `#[tracing::instrument]` on modified handlers |
+
+## Project Structure
+
+### Documentation
+
+```text
+specs/031-portable-apps-folder/
+├── spec.md
+├── plan.md              # This file
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code (files to modify)
+
+```text
+crates/astro-up-core/src/
+├── config/
+│   ├── model.rs          # Add portable_apps_dir to PathsConfig
+│   ├── defaults.rs       # Default path
+│   └── mod.rs            # config_set/config_get for new field
+├── install/
+│   └── mod.rs            # Modify handle_download_only, handle_portable_install
+└── types/
+    └── install.rs        # Add portable_apps_dir to InstallRequest (if needed)
+
+crates/astro-up-gui/src/
+└── commands.rs           # Pass portable_apps_dir to InstallerService
+
+frontend/src/
+├── types/config.ts       # Add portable_apps_dir type
+├── validation/config.ts  # Add validation
+├── views/SettingsView.vue # Add default config value
+└── components/settings/
+    └── PathsSection.vue  # Add input field
+```
+
+## Design
+
+### Config Field
+
+Add `portable_apps_dir: PathBuf` to `PathsConfig`. Default: `{data_dir}/../apps/` which resolves to `{AppData}/nightwatch/astro-up/apps/` on Windows (sibling to the `data/` directory).
+
+### Install Handler Changes
+
+**`handle_download_only`** (the big change):
+1. Remove the `explorer.exe` open behavior
+2. Determine if the download is a zip or single file
+3. If zip: extract to `{portable_apps_dir}/{package-id}/`
+4. If single file: copy to `{portable_apps_dir}/{package-id}/`
+5. Return `InstallResult::Success { path: Some(dest) }`
+6. This handler currently early-returns before hooks/elevation — keep the early return but add the copy logic
+
+**`handle_portable_install`** (small change):
+1. Change `resolve_install_dir` to prefer `portable_apps_dir` when the method is `Portable`
+2. Or: pass `portable_apps_dir` via `InstallRequest` so the installer knows where to put it
+
+### Passing the Config
+
+In `commands.rs`, the `InstallerService` is created with a hardcoded temp dir. Options:
+1. **Simple**: Pass `portable_apps_dir` on `InstallRequest` — the handler reads it from there
+2. **Structural**: Add it to `InstallerService` constructor
+
+Option 1 is simpler and doesn't change the service interface. The `InstallRequest` already has `install_dir: Option<PathBuf>` — for download-only/portable packages, set this to `{portable_apps_dir}/{package-id}`.
+
+### Frontend
+
+Add a "Portable Apps" path input to `PathsSection.vue` with a browse button (reusing the existing pattern from `download_dir`).
+
+### Update Behavior (FR-009)
+
+When updating a portable app that already has a ledger entry with an install path, use that same path as the target. The ledger already stores `install_path` — the orchestrator can pass it through to the `InstallRequest.install_dir`.

--- a/specs/031-portable-apps-folder/quickstart.md
+++ b/specs/031-portable-apps-folder/quickstart.md
@@ -1,0 +1,30 @@
+# Quickstart: Portable Apps Folder
+
+## What Changes
+
+After this feature, `download_only` packages (17 in catalog: firmware tools, NINA caches, utilities) are placed in an organized directory instead of dumped in a temporary download folder.
+
+## User Flow
+
+1. Open Astro-Up, navigate to a download-only package (e.g., iOptron Upgrade Utility)
+2. Click **Install**
+3. The app downloads the file and copies/extracts it to `C:\Users\{you}\AppData\Roaming\nightwatch\astro-up\apps\{package-id}\`
+4. The operations dock shows the destination path — click to open in Explorer
+5. The package appears in the Installed view with the install path visible in Technical tab
+
+## Configuring the Directory
+
+Settings > Paths > **Portable Apps Directory**
+
+Default: `C:\Users\{you}\AppData\Roaming\nightwatch\astro-up\apps\`
+
+Change it to any writable directory (e.g., `D:\AstroTools\`). New installs use the new path; existing apps stay where they are.
+
+## Files Touched
+
+| Area | Files | Change |
+|------|-------|--------|
+| Config model | `config/model.rs`, `defaults.rs`, `mod.rs` | Add `portable_apps_dir` field |
+| Install handlers | `install/mod.rs` | Modify `handle_download_only` to copy/extract; update `handle_portable_install` target |
+| GUI commands | `commands.rs` | Set `install_dir` on `InstallRequest` for download-only/portable |
+| Frontend | `PathsSection.vue`, `config.ts`, `validation.ts`, `SettingsView.vue` | Add path input field |

--- a/specs/031-portable-apps-folder/research.md
+++ b/specs/031-portable-apps-folder/research.md
@@ -1,0 +1,38 @@
+# Research: Portable Apps Folder
+
+## Default Path Selection
+
+**Decision**: `{data_dir}/../apps/` → `{AppData}/Roaming/nightwatch/astro-up/apps/`
+
+**Rationale**: Sibling to the existing `data/` directory. Uses `Roaming` AppData (not `Local`) so it roams with the user profile on domain-joined machines. The `directories` crate already resolves `data_dir` — placing `apps/` as a sibling keeps everything under the same `nightwatch/astro-up/` umbrella.
+
+**Alternatives considered**:
+- `Documents/AstroUp/` — too visible, pollutes Documents
+- `Program Files/AstroUp/` — requires elevation
+- `{Local AppData}/nightwatch/astro-up/apps/` — doesn't roam, but avoids syncing large files. Acceptable alternative.
+
+## Zip Detection Strategy
+
+**Decision**: Check file extension (`.zip`) and magic bytes (`PK\x03\x04`) to determine if download should be extracted vs copied.
+
+**Rationale**: The `zip` crate already exists in the project. Some downloads are zip archives with no `.zip` extension. Checking magic bytes is reliable and cheap (4 bytes).
+
+**Alternatives considered**:
+- Extension-only: misses extensionless zips
+- MIME type: not available from local file
+
+## Install Request Plumbing
+
+**Decision**: Set `InstallRequest.install_dir = Some({portable_apps_dir}/{package-id})` for download-only and portable packages. No changes to `InstallerService` constructor.
+
+**Rationale**: `install_dir` already exists on `InstallRequest` and `resolve_install_dir` already checks it. This minimizes code changes — the GUI commands just set the field before calling the installer.
+
+**Alternatives considered**:
+- Add `portable_apps_dir` to `InstallerService` — more structural change, ties the service to a specific config concept
+- Add a new `InstallMethod::PortableApp` — creates a new variant that manifests would need to adopt
+
+## Explorer Open Removal
+
+**Decision**: Remove the `explorer.exe` spawn from `handle_download_only`. The UI already shows the destination path via `PackageComplete.download_path` — clicking that in the operations dock opens the folder.
+
+**Rationale**: The Explorer spawn is a workaround for having no proper install location. Once files land in the portable dir, the UI path display is sufficient.

--- a/specs/031-portable-apps-folder/spec.md
+++ b/specs/031-portable-apps-folder/spec.md
@@ -1,0 +1,145 @@
+# Feature Specification: Portable Apps Folder
+
+**Feature Branch**: `031-portable-apps-folder`
+**Created**: 2026-04-12
+**Status**: Draft
+**Type**: implementation
+**Input**: User description: "Portable apps folder: configurable directory where non-installable apps (download_only, portable) are placed."
+
+## Current Behavior
+
+Two install methods are relevant:
+
+| Method | Current behavior | Manifests | Handler |
+|--------|-----------------|-----------|---------|
+| `DownloadOnly` | Downloads file, opens Explorer on the download folder. No copy, no hooks, no elevation. Ledger records download dir. | 17 packages (firmware tools, NINA caches, utilities) | `handle_download_only` — early return, skips all install pipeline |
+| `Portable` | Copies downloaded file to `resolve_install_dir()` (temp/download-derived path). Runs hooks, supports uninstall. | 0 packages (unused in practice) | `handle_portable_install` — copies file to target dir |
+
+The key gap: `DownloadOnly` packages end up in a temporary downloads folder with no organization. Users must manually find and relocate them.
+
+## User Scenarios & Testing
+
+### User Story 1 — Install a download-only app to the portable apps folder (Priority: P1)
+
+A user clicks "Install" on a `download_only` package (e.g., a firmware utility or standalone tool). Instead of just opening the download folder in Explorer, the app copies the downloaded file into the user's configured portable apps directory, organized by package name.
+
+**Why this priority**: Core value proposition — 17 packages currently just dump files in a temp folder with no organization.
+
+**Independent Test**: Install a `download_only` package and verify the file appears in the portable apps directory under a package-named subfolder.
+
+**Acceptance Scenarios**:
+
+1. **Given** a package with `method = "download_only"`, **When** the user clicks Install, **Then** the downloaded file is copied to `{portable_apps_dir}/{package-id}/` and the ledger records the install path.
+2. **Given** the download is a zip archive, **When** the install completes, **Then** the archive is extracted (not just copied as a .zip) to the package subfolder.
+3. **Given** an install completes to the portable folder, **When** the operation finishes, **Then** the UI shows the destination path (not "Open download folder").
+
+---
+
+### User Story 2 — Configure the portable apps directory (Priority: P2)
+
+A user navigates to Settings > Paths and sets a custom directory for portable apps. This persists across sessions and is used for all future portable/download-only installs.
+
+**Why this priority**: Users need control over where files go, especially if the default location doesn't suit them (e.g., limited disk space on C:, preference for a dedicated tools drive).
+
+**Independent Test**: Change the portable apps directory in Settings, install a portable package, verify it lands in the new location.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Settings > Paths section, **When** the user sets a custom portable apps directory, **Then** the setting persists and is used for the next portable install.
+2. **Given** no custom directory is set, **When** a portable package is installed, **Then** the default directory is used (`{app_data}/nightwatch/astro-up/apps/`).
+3. **Given** the configured directory does not exist, **When** a portable install starts, **Then** the directory is created automatically.
+
+---
+
+### User Story 3 — View and open the portable app location (Priority: P2)
+
+After a portable app is installed, the user can see where it was placed and open the folder directly from the app's detail page.
+
+**Why this priority**: Users need to find the installed portable app to create shortcuts, add it to PATH, or launch it manually.
+
+**Independent Test**: Install a portable app, navigate to its detail page, verify the install path is visible and the "Open folder" action works.
+
+**Acceptance Scenarios**:
+
+1. **Given** a portable app is installed, **When** the user views the package detail, **Then** the install path is displayed in the Technical or Overview tab.
+2. **Given** a portable app is installed, **When** the user clicks "Open folder" on the install path, **Then** the file explorer opens at that location.
+
+---
+
+### User Story 4 — Update replaces the app in-place (Priority: P3)
+
+When a newer version of a download-only app is available and the user updates, the new version replaces the old one in the same portable folder location.
+
+**Why this priority**: Without this, updates would create duplicate copies or leave old versions behind.
+
+**Independent Test**: Install a download-only app, trigger an update, verify the old version is replaced and the ledger reflects the new version.
+
+**Acceptance Scenarios**:
+
+1. **Given** a download-only app is installed at `{portable_apps_dir}/{package-id}/`, **When** the user updates to a newer version, **Then** the old files are replaced with the new version in the same location.
+2. **Given** an update is in progress, **When** the old version is replaced, **Then** the ledger is updated with the new version and the same install path.
+
+---
+
+### User Story 5 — Portable method uses the same folder (Priority: P3)
+
+If any manifests are later changed to `method = "portable"`, the `handle_portable_install` handler should also use the configured portable apps directory instead of the current temp-derived path.
+
+**Why this priority**: Currently 0 manifests use `portable`, but the method exists in the codebase. Aligning it with the new folder ensures consistency if adopted later.
+
+**Independent Test**: Create a test manifest with `method = "portable"`, install it, verify it lands in the portable apps folder.
+
+**Acceptance Scenarios**:
+
+1. **Given** a package with `method = "portable"`, **When** installed, **Then** the file is copied to `{portable_apps_dir}/{package-id}/` (same as download-only).
+
+---
+
+### Edge Cases
+
+- What happens when the portable apps directory is on a drive that doesn't exist or is full? Show a clear error message and suggest changing the directory in Settings.
+- What happens when a portable app's download is a single `.exe` (not a zip)? Copy the exe directly into `{portable_apps_dir}/{package-id}/`.
+- What happens when the user changes the portable directory after apps are already installed? Existing apps stay where they are; only new installs use the new directory. The ledger tracks actual paths.
+- What happens when a portable app has a nested folder structure inside the zip? Extract preserving the structure into the package subfolder.
+- Package IDs are enforced as `[a-z0-9-]` by the catalog schema — always valid as directory names.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST provide a configurable setting for the portable apps directory with a sensible default path.
+- **FR-002**: The default portable apps directory MUST be under the user's profile directory (not a system-wide path requiring elevation).
+- **FR-003**: When installing a `download_only` package, the system MUST copy the downloaded file to `{portable_apps_dir}/{package-id}/` instead of opening Explorer on the download folder.
+- **FR-004**: When the downloaded file is a zip archive, the system MUST extract its contents to the package subfolder (not copy the zip as-is).
+- **FR-004a**: The `handle_portable_install` handler MUST also use the configured portable apps directory as the install target.
+- **FR-005**: After a portable install completes, the ledger MUST record the install path pointing to the portable apps directory.
+- **FR-006**: The operation completion event MUST include the destination path so the UI can display it.
+- **FR-007**: The portable apps directory MUST be created automatically if it does not exist.
+- **FR-008**: The Settings > Paths section MUST include a field for configuring the portable apps directory.
+- **FR-009**: When updating a portable app, the system MUST replace the old version in the same location.
+- **FR-010**: The package detail view MUST show the install path for portable apps with an "Open folder" action.
+
+### Key Entities
+
+- **Portable Apps Directory**: A user-configurable path where non-installer packages are placed. Stored as a config setting. Defaults to a location under the user's app data directory.
+- **Install Path**: Recorded in the ledger for each installed package. For portable apps, points to the package subfolder within the portable apps directory.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: Portable/download-only packages are placed in an organized directory instead of left in the downloads folder.
+- **SC-002**: Users can find installed portable apps without manually searching the downloads folder.
+- **SC-003**: The portable apps directory setting is discoverable in Settings within 10 seconds.
+- **SC-004**: Portable app install completes within 5 seconds of download finishing (copy/extract time).
+- **SC-005**: 100% of portable installs record the correct path in the ledger.
+
+## Assumptions
+
+- The portable apps directory is per-user, not system-wide — no elevation is needed.
+- `DownloadOnly` currently early-returns in the install pipeline (skips hooks, elevation, zip handling). This feature replaces `handle_download_only` with a proper copy/extract flow.
+- `Portable` handler already copies files but targets a temp-derived path. This feature changes its target to the portable apps dir.
+- Zip extraction uses the existing `zip` crate already in the codebase (used by `handle_zip_install`).
+- The `install_path` field on `PackageComplete` events and ledger entries already exists — this feature populates it for portable/download-only packages.
+- Windows is the only target platform; the default path uses Windows conventions (`AppData`).
+- 17 manifests currently use `download_only`; 0 use `portable`. The primary impact is on `download_only`.

--- a/specs/031-portable-apps-folder/tasks.md
+++ b/specs/031-portable-apps-folder/tasks.md
@@ -1,0 +1,184 @@
+# Tasks: Portable Apps Folder
+
+**Input**: Design documents from `/specs/031-portable-apps-folder/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, quickstart.md
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1–US5)
+
+## Phase 1: Setup (Config Field)
+
+**Purpose**: Add the `portable_apps_dir` config field across backend and frontend
+
+- [ ] T001 [P] Add `portable_apps_dir: PathBuf` field to `PathsConfig` in `crates/astro-up-core/src/config/model.rs`
+- [ ] T002 [P] Add default value for `portable_apps_dir` in `crates/astro-up-core/src/config/defaults.rs` — default to `{data_dir}/../apps/` resolving to `{AppData}/nightwatch/astro-up/apps/`
+- [ ] T003 Add `config_set`/`config_get` match arms for `paths.portable_apps_dir` in `crates/astro-up-core/src/config/mod.rs`
+- [ ] T004 Update config snapshot test in `crates/astro-up-core/tests/config/defaults_test.rs` — add `portable_apps_dir` to expected output and update key count
+
+---
+
+## Phase 2: Foundational (Install Handler Changes)
+
+**Purpose**: Modify `handle_download_only` to copy/extract instead of opening Explorer. Wire the portable dir into the install pipeline.
+
+- [ ] T005 Rewrite `handle_download_only` in `crates/astro-up-core/src/install/mod.rs` — replace Explorer open with: detect if file is zip (check magic bytes `PK\x03\x04`), extract if zip using existing `zip::extract_zip`, copy if single file. Create `{dest}/{package-id}/` dir. Return `InstallResult::Success { path: Some(dest) }`
+- [ ] T006 In `crates/astro-up-gui/src/commands.rs` `run_orchestrated_operation_inner`, when install method is `DownloadOnly` or `Portable`, set `InstallRequest.install_dir = Some(config.paths.portable_apps_dir.join(package_id))`. Read `portable_apps_dir` from `config.paths`
+
+**Checkpoint**: Download-only packages now land in the portable apps directory
+
+---
+
+## Phase 3: User Story 1 — Install download-only app to portable folder (Priority: P1)
+
+**Goal**: `download_only` packages copy/extract to `{portable_apps_dir}/{package-id}/` with ledger recording the install path.
+
+**Independent Test**: Install `ioptron-upgrade-utility-v3` on .111, verify file appears in `apps/` dir, verify ledger has install_path.
+
+- [ ] T007 [US1] Verify the orchestrator passes `install_dir` through to `InstallRequest` for download-only packages — trace the flow in `crates/astro-up-core/src/engine/orchestrator.rs` from `plan` through `execute_single`. Fix if not threaded through. Also verify the CLI install command in `crates/astro-up-cli/src/commands/install.rs` passes `portable_apps_dir` from config.
+- [ ] T008 [US1] Verify the `PackageComplete` event emits the portable dir path (not the temp download dir) via `download_path` field — check event emission in `crates/astro-up-core/src/engine/orchestrator.rs`
+- [ ] T009 [US1] Verify the ledger `upsert_acknowledged` records `install_path` from `InstallResult::Success { path }` for download-only packages
+
+**Checkpoint**: US1 complete — download-only packages install to portable dir with correct ledger and events
+
+---
+
+## Phase 4: User Story 2 — Configure the portable apps directory (Priority: P2)
+
+**Goal**: Settings > Paths has a field for the portable apps directory.
+
+**Independent Test**: Change path in Settings, install a download-only package, verify it uses the new path.
+
+- [ ] T010 [P] [US2] Add `portable_apps_dir: string` to `PathsConfig` interface in `frontend/src/types/config.ts`
+- [ ] T011 [P] [US2] Add `portable_apps_dir` validation in `frontend/src/validation/config.ts`
+- [ ] T012 [P] [US2] Add default `portable_apps_dir: ""` to `defaultConfig.paths` in `frontend/src/views/SettingsView.vue`
+- [ ] T013 [US2] Add "Portable Apps Directory" input with browse button to `frontend/src/components/settings/PathsSection.vue` — reuse the pattern from the `download_dir` field
+
+**Checkpoint**: US2 complete — settings UI shows and persists the portable apps dir
+
+---
+
+## Phase 5: User Story 3 — View and open portable app location (Priority: P2)
+
+**Goal**: Package detail shows install path with clickable "Open folder" action.
+
+**Independent Test**: Install a portable app, navigate to detail, see path, click to open.
+
+- [ ] T014 [US3] Display `install_path` in `frontend/src/components/detail/OverviewTab.vue` when present — show path text with a clickable folder icon that calls `open()` from `@tauri-apps/plugin-shell`
+- [ ] T015 [US3] Verify `list_software` in `crates/astro-up-gui/src/commands.rs` includes `install_path` from the ledger in the enriched package JSON — check if already present from detection cache or ledger enrichment
+
+**Checkpoint**: US3 complete — install path visible and openable
+
+---
+
+## Phase 6: User Story 4 — Update replaces in-place (Priority: P3)
+
+**Goal**: Updating a portable app replaces old version in same location.
+
+**Independent Test**: Install, then update — verify old files replaced, ledger updated.
+
+- [ ] T016 [US4] In `handle_download_only` (`crates/astro-up-core/src/install/mod.rs`), when target dir already exists, delete its contents before copying/extracting the new version (clean replace)
+- [ ] T017 [US4] Verify the orchestrator passes the existing ledger `install_path` as `install_dir` on the `InstallRequest` when updating a package that already has a recorded path — check `crates/astro-up-core/src/engine/orchestrator.rs`
+
+**Checkpoint**: US4 complete — updates replace in-place
+
+---
+
+## Phase 7: User Story 5 — Portable method alignment (Priority: P3)
+
+**Goal**: `handle_portable_install` uses the portable apps dir (same as download-only).
+
+**Independent Test**: Test with `method = "portable"`, verify it lands in the portable apps folder.
+
+- [ ] T018 [US5] Verify `handle_portable_install` in `crates/astro-up-core/src/install/mod.rs` uses `resolve_install_dir` which reads `install_dir` from request — T006 already sets this for Portable method. Document verification or fix if needed.
+
+**Checkpoint**: US5 complete — portable method aligned
+
+---
+
+## Phase 8: Polish & Cross-Cutting
+
+- [ ] T019 [P] Add integration test for download-only portable install in `crates/astro-up-core/tests/` — create a test zip, run through `handle_download_only`, verify extraction to target dir
+- [ ] T020 [P] Update `docs/reference/config.md` with `portable_apps_dir` field
+- [ ] T021 [MANUAL] Run quickstart.md validation on .111 — install a download-only package end-to-end, verify portable dir, ledger, UI path display
+
+---
+
+## Task Dependencies
+
+<!-- Machine-readable. Generated by /speckit.tasks, updated by /speckit.iterate.apply -->
+<!-- Do not edit manually unless you also update GitHub issue dependencies -->
+
+```toml
+[graph]
+T001.blocked_by = []
+T002.blocked_by = []
+T003.blocked_by = ["T001", "T002"]
+T004.blocked_by = ["T003"]
+T005.blocked_by = []
+T006.blocked_by = ["T003", "T005"]
+T007.blocked_by = ["T006"]
+T008.blocked_by = ["T007"]
+T009.blocked_by = ["T007"]
+T010.blocked_by = []
+T011.blocked_by = []
+T012.blocked_by = []
+T013.blocked_by = ["T010", "T011", "T012"]
+T014.blocked_by = ["T009"]
+T015.blocked_by = ["T009"]
+T016.blocked_by = ["T005"]
+T017.blocked_by = ["T009"]
+T018.blocked_by = ["T006"]
+T019.blocked_by = ["T005"]
+T020.blocked_by = ["T003"]
+T021.blocked_by = ["T009", "T013"]
+```
+
+## Parallel Opportunities
+
+**Phase 1** (config, all parallel):
+```
+T001 (model) | T002 (defaults) — different files
+```
+
+**Phase 2** (T005 independent of T001/T002):
+```
+T005 (handler rewrite) can start immediately — no config dependency
+T006 waits for both T003 and T005
+```
+
+**Phase 4** (frontend, all parallel):
+```
+T010 (types) | T011 (validation) | T012 (defaults) — different files
+```
+
+**Phase 8** (all parallel):
+```
+T019 (test) | T020 (docs) — independent
+```
+
+## Implementation Strategy
+
+### MVP (User Story 1 Only)
+
+1. T001-T004: Config field setup
+2. T005-T006: Handler rewrite + wiring
+3. T007-T009: Verify US1 end-to-end
+4. **STOP and VALIDATE** on .111
+
+### Full Delivery
+
+5. T010-T013: Settings UI (US2)
+6. T014-T015: Detail view path display (US3)
+7. T016-T017: Update in-place (US4)
+8. T018: Portable alignment (US5)
+9. T019-T021: Polish
+
+## Notes
+
+- T005 is the largest task — rewriting `handle_download_only` from "open Explorer" to "copy/extract"
+- T006 is the critical wiring — injecting portable dir path into the install pipeline
+- T018 may be a no-op if `resolve_install_dir` already works correctly with the `install_dir` set by T006
+- [MANUAL] T021 requires .111 Windows machine access
+- 21 tasks total across 8 phases

--- a/specs/031-portable-apps-folder/tasks.md
+++ b/specs/031-portable-apps-folder/tasks.md
@@ -12,9 +12,9 @@
 
 **Purpose**: Add the `portable_apps_dir` config field across backend and frontend
 
-- [ ] T001 [P] Add `portable_apps_dir: PathBuf` field to `PathsConfig` in `crates/astro-up-core/src/config/model.rs`
-- [ ] T002 [P] Add default value for `portable_apps_dir` in `crates/astro-up-core/src/config/defaults.rs` — default to `{data_dir}/../apps/` resolving to `{AppData}/nightwatch/astro-up/apps/`
-- [ ] T003 Add `config_set`/`config_get` match arms for `paths.portable_apps_dir` in `crates/astro-up-core/src/config/mod.rs`
+- [x] T001 [P] Add `portable_apps_dir: PathBuf` field to `PathsConfig` in `crates/astro-up-core/src/config/model.rs`
+- [x] T002 [P] Add default value for `portable_apps_dir` in `crates/astro-up-core/src/config/defaults.rs` — default to `{data_dir}/../apps/` resolving to `{AppData}/nightwatch/astro-up/apps/`
+- [x] T003 Add `config_set`/`config_get` match arms for `paths.portable_apps_dir` in `crates/astro-up-core/src/config/mod.rs`
 - [ ] T004 Update config snapshot test in `crates/astro-up-core/tests/config/defaults_test.rs` — add `portable_apps_dir` to expected output and update key count
 
 ---
@@ -23,8 +23,8 @@
 
 **Purpose**: Modify `handle_download_only` to copy/extract instead of opening Explorer. Wire the portable dir into the install pipeline.
 
-- [ ] T005 Rewrite `handle_download_only` in `crates/astro-up-core/src/install/mod.rs` — replace Explorer open with: detect if file is zip (check magic bytes `PK\x03\x04`), extract if zip using existing `zip::extract_zip`, copy if single file. Create `{dest}/{package-id}/` dir. Return `InstallResult::Success { path: Some(dest) }`
-- [ ] T006 In `crates/astro-up-gui/src/commands.rs` `run_orchestrated_operation_inner`, when install method is `DownloadOnly` or `Portable`, set `InstallRequest.install_dir = Some(config.paths.portable_apps_dir.join(package_id))`. Read `portable_apps_dir` from `config.paths`
+- [x] T005 Rewrite `handle_download_only` in `crates/astro-up-core/src/install/mod.rs` — replace Explorer open with: detect if file is zip (check magic bytes `PK\x03\x04`), extract if zip using existing `zip::extract_zip`, copy if single file. Create `{dest}/{package-id}/` dir. Return `InstallResult::Success { path: Some(dest) }`
+- [x] T006 In `crates/astro-up-gui/src/commands.rs` `run_orchestrated_operation_inner`, when install method is `DownloadOnly` or `Portable`, set `InstallRequest.install_dir = Some(config.paths.portable_apps_dir.join(package_id))`. Read `portable_apps_dir` from `config.paths`
 
 **Checkpoint**: Download-only packages now land in the portable apps directory
 
@@ -50,10 +50,10 @@
 
 **Independent Test**: Change path in Settings, install a download-only package, verify it uses the new path.
 
-- [ ] T010 [P] [US2] Add `portable_apps_dir: string` to `PathsConfig` interface in `frontend/src/types/config.ts`
-- [ ] T011 [P] [US2] Add `portable_apps_dir` validation in `frontend/src/validation/config.ts`
-- [ ] T012 [P] [US2] Add default `portable_apps_dir: ""` to `defaultConfig.paths` in `frontend/src/views/SettingsView.vue`
-- [ ] T013 [US2] Add "Portable Apps Directory" input with browse button to `frontend/src/components/settings/PathsSection.vue` — reuse the pattern from the `download_dir` field
+- [x] T010 [P] [US2] Add `portable_apps_dir: string` to `PathsConfig` interface in `frontend/src/types/config.ts`
+- [x] T011 [P] [US2] Add `portable_apps_dir` validation in `frontend/src/validation/config.ts`
+- [x] T012 [P] [US2] Add default `portable_apps_dir: ""` to `defaultConfig.paths` in `frontend/src/views/SettingsView.vue`
+- [x] T013 [US2] Add "Portable Apps Directory" input with browse button to `frontend/src/components/settings/PathsSection.vue` — reuse the pattern from the `download_dir` field
 
 **Checkpoint**: US2 complete — settings UI shows and persists the portable apps dir
 
@@ -65,7 +65,7 @@
 
 **Independent Test**: Install a portable app, navigate to detail, see path, click to open.
 
-- [ ] T014 [US3] Display `install_path` in `frontend/src/components/detail/OverviewTab.vue` when present — show path text with a clickable folder icon that calls `open()` from `@tauri-apps/plugin-shell`
+- [x] T014 [US3] Display `install_path` in `frontend/src/components/detail/OverviewTab.vue` when present — show path text with a clickable folder icon that calls `open()` from `@tauri-apps/plugin-shell`
 - [ ] T015 [US3] Verify `list_software` in `crates/astro-up-gui/src/commands.rs` includes `install_path` from the ledger in the enriched package JSON — check if already present from detection cache or ledger enrichment
 
 **Checkpoint**: US3 complete — install path visible and openable
@@ -78,7 +78,7 @@
 
 **Independent Test**: Install, then update — verify old files replaced, ledger updated.
 
-- [ ] T016 [US4] In `handle_download_only` (`crates/astro-up-core/src/install/mod.rs`), when target dir already exists, delete its contents before copying/extracting the new version (clean replace)
+- [x] T016 [US4] In `handle_download_only` (`crates/astro-up-core/src/install/mod.rs`), when target dir already exists, delete its contents before copying/extracting the new version (clean replace)
 - [ ] T017 [US4] Verify the orchestrator passes the existing ledger `install_path` as `install_dir` on the `InstallRequest` when updating a package that already has a recorded path — check `crates/astro-up-core/src/engine/orchestrator.rs`
 
 **Checkpoint**: US4 complete — updates replace in-place


### PR DESCRIPTION
## Summary
Add a configurable portable apps directory where `download_only` packages are organized instead of being dumped in a temp folder.

- New config field `paths.portable_apps_dir` (default: `{AppData}/nightwatch/astro-up/apps/`)
- `handle_download_only` rewritten: detects zip (magic bytes), extracts or copies to `{portable_apps_dir}/{package-id}/`
- Orchestrator threads `portable_apps_dir` from config through `UpdateRequest` → `UpdatePlan` → `InstallRequest.install_dir`
- Settings > Paths UI with browse button
- Install path displayed in package detail OverviewTab with "Open folder" action
- CLI install/update commands also pass the portable dir
- Clean replace on update (deletes old contents before extracting new version)

Affects 17 `download_only` packages (firmware tools, NINA caches, utilities). 0 `portable` packages (method aligned but unused).

## Spec Context
Spec 031: `specs/031-portable-apps-folder/`

## Test plan
- [ ] Config snapshot tests updated (key count 44 → 45)
- [ ] All 457 tests pass (cargo test + clippy + fmt)
- [ ] Install a download-only package on .111 — verify file lands in `apps/{id}/`
- [ ] Change portable dir in Settings — verify next install uses new path
- [ ] Update a portable app — verify old version replaced
- [ ] Verify install path visible in detail view with working "Open folder"
