### PR TITLE
fix(ci): verify manifest tag exists before running release-please

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,32 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       release_notes: ${{ steps.notes.outputs.combined }}
     steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Verify manifest tag exists
+        id: tag-check
+        shell: bash
+        run: |
+          VERSION=$(jq -r '.["."]//"0.0.0"' .release-please-manifest.json)
+          TAG="v${VERSION}"
+          if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+            echo "Tag ${TAG} exists — release-please can proceed safely"
+          else
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
+            echo "::warning::Tag ${TAG} not found — this run may have been triggered before the previous release completed. Waiting 30s for tag propagation..."
+            sleep 30
+            git fetch --tags
+            if git rev-parse "refs/tags/${TAG}" >/dev/null 2>&1; then
+              echo "tag_exists=true" >> "$GITHUB_OUTPUT"
+              echo "Tag ${TAG} found after wait"
+            else
+              echo "::warning::Tag ${TAG} still not found after wait — release-please may generate incorrect changelog"
+            fi
+          fi
+
       - name: Generate app token
         id: app-token
         uses: actions/create-github-app-token@v3


### PR DESCRIPTION
## Summary
Fix the recurring issue where release-please creates PRs with full project history instead of just changes since the last release.

**Root cause**: When a release PR merges, workflow run A creates the release tag. But queued workflow runs (from dependabot or other merges) start release-please before the tag is visible, causing it to scan from the beginning of git history.

**Fix**: 
1. Add a tag verification step before release-please runs — checks if the manifest version's tag exists
2. If tag is missing, waits 30s and retries with `git fetch --tags`
3. Also deleted the stale `release-please--branches--main--components--astro-up` branch which was carrying the bogus PR state

## Test plan
- [ ] Merge this PR, then merge another PR — verify the next release PR only contains changes since v0.1.27
- [ ] No more "full history" in release notes
