### PR TITLE
fix: remove draft release to eliminate tag race condition

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,8 +3,6 @@
   "release-type": "rust",
   "bump-minor-pre-major": true,
   "bump-patch-for-minor-pre-major": true,
-  "draft": true,
-  "force-tag-creation": true,
   "include-component-in-tag": false,
   "packages": {
     ".": {


### PR DESCRIPTION
## Summary
Remove `"draft": true` and `"force-tag-creation": true` from release-please config.

Without draft mode, release-please creates a **published** release with the tag atomically on merge. No more race condition where subsequent workflow runs can't find the tag.

The build workflow (`tauri-action`) already handles the draft→publish lifecycle independently via `releaseDraft: true` and the `publish-release` job.

Supersedes #1017 (tag verification step is no longer needed).

## Test plan
- [ ] Merge this PR, then merge another PR
- [ ] Verify release-please PR only contains changes since last release (no full history)
