### PR TITLE
fix: render update release notes as markdown with clickable links

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -23,6 +23,7 @@
     "@tauri-apps/plugin-window-state": "^2",
     "@vueuse/core": "^14",
     "primevue": "^4.5.5",
+    "snarkdown": "^2.0.0",
     "valibot": "^1",
     "vue": "^3",
     "vue-router": "^5"

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       primevue:
         specifier: ^4.5.5
         version: 4.5.5(vue@3.5.32(typescript@6.0.2))
+      snarkdown:
+        specifier: ^2.0.0
+        version: 2.0.0
       valibot:
         specifier: ^1
         version: 1.3.1(typescript@6.0.2)
@@ -1266,6 +1269,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  snarkdown@2.0.0:
+    resolution: {integrity: sha512-MgL/7k/AZdXCTJiNgrO7chgDqaB9FGM/1Tvlcenenb7div6obaDATzs16JhFyHHBGodHT3B7RzRc5qk8pFhg3A==}
 
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
@@ -2755,6 +2761,8 @@ snapshots:
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
+
+  snarkdown@2.0.0: {}
 
   source-map-js@1.2.1: {}
 

--- a/frontend/src/components/settings/AboutSection.vue
+++ b/frontend/src/components/settings/AboutSection.vue
@@ -4,6 +4,7 @@ import Button from "primevue/button";
 import Dialog from "primevue/dialog";
 import { useToast } from "primevue/usetoast";
 import { open as openUrl } from "@tauri-apps/plugin-shell";
+import MarkdownContent from "../shared/MarkdownContent.vue";
 
 const toast = useToast();
 
@@ -24,6 +25,7 @@ async function checkForUpdates() {
       updateVersion.value = update.version;
       updateNotes.value = update.body ?? "";
       showNotes.value = true;
+
     } else {
       updateAvailable.value = false;
       updateVersion.value = "";
@@ -110,10 +112,11 @@ async function installUpdate() {
       modal
       :style="{ width: '500px', maxHeight: '80vh' }"
     >
-      <pre
+      <MarkdownContent
         v-if="updateNotes"
+        :content="updateNotes"
         class="release-notes"
-      >{{ updateNotes }}</pre>
+      />
       <p v-else>
         A new version is available.
       </p>
@@ -158,13 +161,6 @@ async function installUpdate() {
 }
 .about-link:hover { text-decoration: underline; }
 .release-notes {
-  font-family: inherit;
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--p-surface-200);
-  white-space: pre-wrap;
-  word-wrap: break-word;
-  margin: 0;
   max-height: 400px;
   overflow-y: auto;
 }

--- a/frontend/src/components/shared/MarkdownContent.vue
+++ b/frontend/src/components/shared/MarkdownContent.vue
@@ -1,0 +1,45 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { open as openUrl } from "@tauri-apps/plugin-shell";
+import snarkdown from "snarkdown";
+
+const props = defineProps<{
+  content: string;
+}>();
+
+const rendered = computed(() =>
+  snarkdown(props.content),
+);
+
+function handleClick(e: MouseEvent) {
+  const target = e.target as HTMLElement;
+  const anchor = target.closest("a");
+  if (anchor?.href) {
+    e.preventDefault();
+    openUrl(anchor.href);
+  }
+}
+</script>
+
+<template>
+  <div
+    class="markdown-content"
+    v-html="rendered"
+    @click="handleClick"
+  />
+</template>
+
+<style scoped>
+.markdown-content {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--p-surface-200);
+}
+.markdown-content :deep(h2) { font-size: 15px; margin: 0 0 8px; color: var(--p-surface-100); }
+.markdown-content :deep(h3) { font-size: 14px; margin: 12px 0 6px; color: var(--p-surface-100); }
+.markdown-content :deep(ul) { padding-left: 20px; margin: 4px 0; }
+.markdown-content :deep(li) { margin: 2px 0; }
+.markdown-content :deep(a) { color: var(--p-primary-400); text-decoration: none; cursor: pointer; }
+.markdown-content :deep(a:hover) { text-decoration: underline; }
+.markdown-content :deep(code) { background: var(--p-surface-800); padding: 1px 4px; border-radius: 3px; font-size: 12px; }
+</style>


### PR DESCRIPTION
## Summary
Render update release notes as markdown with clickable links that open in the system browser.

- New `MarkdownContent.vue` component using `snarkdown` (1KB) for lightweight markdown rendering
- Links intercepted via click handler → `@tauri-apps/plugin-shell` `open()` (opens in system browser, not WebView)
- Styled for dark theme: headings, lists, links, inline code
- Replaces raw `<pre>` text in the update dialog

## Test plan
- [ ] Check for updates in Settings > About — verify release notes render with headings, bullet lists, clickable links
- [ ] Click a link in release notes — verify it opens in system browser
