### PR TITLE
fix: elevate installer process with sudo/runas instead of app re-exec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.29"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.26"
+version = "0.1.29"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.26"
+version = "0.1.29"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.26"
+version = "0.1.29"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/crates/astro-up-core/src/install/elevation.rs
+++ b/crates/astro-up-core/src/install/elevation.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::error::CoreError;
 
 /// Checks if the current process is running with admin privileges.
@@ -32,84 +34,171 @@ fn which_sudo() -> Option<std::path::PathBuf> {
     })
 }
 
-/// Re-executes the current process with elevated privileges.
+/// Spawns an installer process with elevated (admin) privileges.
+///
+/// Elevates only the installer process — the calling application continues
+/// running unprivileged. This avoids re-executing the entire app, which would
+/// restart the GUI in Tauri.
 ///
 /// Strategy:
-/// 1. If `sudo.exe` is on PATH (Windows 11 24H2+), use it for inline elevation.
-/// 2. Otherwise, use `ShellExecuteExW` with the `runas` verb (opens new window).
+/// 1. If `sudo.exe` is on PATH (Windows 11 24H2+), prefix the command with `sudo`.
+/// 2. Otherwise, use `ShellExecuteExW` with the `runas` verb to trigger a UAC prompt.
+///
+/// Returns the installer process exit code.
 #[cfg(windows)]
-#[tracing::instrument(skip_all)]
-pub async fn elevate_and_reexec(args: &[String]) -> Result<(), CoreError> {
-    let current_exe = std::env::current_exe()?;
-    tracing::info!(exe = %current_exe.display(), args_count = args.len(), "re-executing with elevated privileges");
+#[tracing::instrument(skip_all, fields(exe = %exe, timeout_secs = timeout.as_secs()))]
+pub async fn spawn_elevated(
+    exe: &str,
+    args: &[String],
+    timeout: Duration,
+) -> Result<i32, CoreError> {
+    tracing::info!(args = ?args, "spawning installer with elevation");
 
     if detect_sudo() {
-        // Sudo path: inline elevation in the same terminal
-        let status = tokio::process::Command::new("sudo")
-            .arg(&current_exe)
-            .args(args)
-            .status()
-            .await?;
-
-        if status.success() {
-            Ok(())
-        } else {
-            Err(CoreError::ElevationRequired)
-        }
+        spawn_elevated_sudo(exe, args, timeout).await
     } else {
-        // ShellExecuteExW uses PCWSTR (*const u16) which is !Send.
-        // Move the entire call into spawn_blocking to keep the async future Send.
-        let exe_path = current_exe.to_string_lossy().to_string();
-        let args_str = args.join(" ");
-
-        tokio::task::spawn_blocking(move || {
-            use super::wide::to_wide_null;
-            use windows::Win32::UI::Shell::{
-                SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW,
-            };
-            use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
-            use windows::core::PCWSTR;
-
-            let exe_wide = to_wide_null(&exe_path);
-            let args_wide = to_wide_null(&args_str);
-            let verb_wide = to_wide_null("runas");
-
-            let mut sei = SHELLEXECUTEINFOW {
-                cbSize: std::mem::size_of::<SHELLEXECUTEINFOW>() as u32,
-                fMask: SEE_MASK_NOCLOSEPROCESS,
-                lpVerb: PCWSTR(verb_wide.as_ptr()),
-                lpFile: PCWSTR(exe_wide.as_ptr()),
-                lpParameters: PCWSTR(args_wide.as_ptr()),
-                nShow: SW_HIDE.0,
-                ..Default::default()
-            };
-
-            let success = unsafe { ShellExecuteExW(std::ptr::from_mut(&mut sei)) };
-            if success.is_ok() {
-                if !sei.hProcess.is_invalid() {
-                    unsafe {
-                        windows::Win32::System::Threading::WaitForSingleObject(
-                            sei.hProcess,
-                            windows::Win32::System::Threading::INFINITE,
-                        );
-                        windows::Win32::Foundation::CloseHandle(sei.hProcess).ok();
-                    }
-                }
-                Ok(())
-            } else {
-                Err(CoreError::ElevationRequired)
-            }
-        })
-        .await
-        .map_err(|e| CoreError::Io(std::io::Error::other(e)))?
+        spawn_elevated_runas(exe, args, timeout).await
     }
 }
 
+/// Elevation via `sudo.exe` (Windows 11 24H2+). Inline elevation — no new window.
+#[cfg(windows)]
+async fn spawn_elevated_sudo(
+    exe: &str,
+    args: &[String],
+    timeout: Duration,
+) -> Result<i32, CoreError> {
+    use std::time::Instant;
+
+    tracing::info!("using sudo.exe for inline elevation");
+    let start = Instant::now();
+
+    let mut child = tokio::process::Command::new("sudo")
+        .arg(exe)
+        .args(args)
+        .kill_on_drop(true)
+        .spawn()
+        .map_err(|e| {
+            tracing::error!(error = %e, "failed to spawn sudo process");
+            CoreError::Io(e)
+        })?;
+
+    tokio::select! {
+        result = child.wait() => {
+            let status = result?;
+            let code = status.code().unwrap_or(-1);
+            tracing::info!(
+                exit_code = code,
+                duration_ms = start.elapsed().as_millis() as u64,
+                "elevated installer process exited"
+            );
+            Ok(code)
+        }
+        () = tokio::time::sleep(timeout) => {
+            if let Err(e) = child.kill().await {
+                tracing::trace!(error = %e, "failed to kill elevated process during timeout");
+            }
+            tracing::warn!(
+                timeout_secs = timeout.as_secs(),
+                duration_ms = start.elapsed().as_millis() as u64,
+                "elevated installer process timed out"
+            );
+            Err(CoreError::InstallerTimeout { timeout_secs: timeout.as_secs() })
+        }
+    }
+}
+
+/// Elevation via `ShellExecuteExW` with `runas` verb (pre-Win11 24H2).
+/// Shows a UAC prompt and waits for the elevated process to complete.
+#[cfg(windows)]
+async fn spawn_elevated_runas(
+    exe: &str,
+    args: &[String],
+    timeout: Duration,
+) -> Result<i32, CoreError> {
+    tracing::info!("using ShellExecuteExW runas for UAC elevation");
+
+    let exe_owned = exe.to_owned();
+    let args_str = args.join(" ");
+    let timeout_ms = timeout.as_millis() as u32;
+
+    tokio::task::spawn_blocking(move || {
+        use super::wide::to_wide_null;
+        use windows::Win32::Foundation::CloseHandle;
+        use windows::Win32::System::Threading::{GetExitCodeProcess, WaitForSingleObject};
+        use windows::Win32::UI::Shell::{
+            SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW,
+        };
+        use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
+        use windows::core::PCWSTR;
+
+        let exe_wide = to_wide_null(&exe_owned);
+        let args_wide = to_wide_null(&args_str);
+        let verb_wide = to_wide_null("runas");
+
+        let mut sei = SHELLEXECUTEINFOW {
+            cbSize: std::mem::size_of::<SHELLEXECUTEINFOW>() as u32,
+            fMask: SEE_MASK_NOCLOSEPROCESS,
+            lpVerb: PCWSTR(verb_wide.as_ptr()),
+            lpFile: PCWSTR(exe_wide.as_ptr()),
+            lpParameters: PCWSTR(args_wide.as_ptr()),
+            nShow: SW_HIDE.0,
+            ..Default::default()
+        };
+
+        let result = unsafe { ShellExecuteExW(std::ptr::from_mut(&mut sei)) };
+        if result.is_err() {
+            tracing::warn!("ShellExecuteExW runas failed — user may have declined UAC");
+            return Err(CoreError::ElevationRequired);
+        }
+
+        if sei.hProcess.is_invalid() {
+            tracing::warn!("ShellExecuteExW returned no process handle");
+            return Err(CoreError::ElevationRequired);
+        }
+
+        let wait = unsafe { WaitForSingleObject(sei.hProcess, timeout_ms) };
+        let code = if wait.0 == 0 {
+            // WAIT_OBJECT_0 — process exited
+            let mut exit_code: u32 = 0;
+            unsafe {
+                if let Err(e) = GetExitCodeProcess(sei.hProcess, &raw mut exit_code) {
+                    tracing::trace!(error = %e, "failed to get exit code from elevated process");
+                }
+            }
+            tracing::info!(
+                exit_code = exit_code as i32,
+                "elevated installer process exited"
+            );
+            Ok(exit_code as i32)
+        } else {
+            // WAIT_TIMEOUT or error
+            tracing::warn!(
+                timeout_secs = timeout.as_secs(),
+                "elevated installer process timed out"
+            );
+            Err(CoreError::InstallerTimeout {
+                timeout_secs: timeout.as_secs(),
+            })
+        };
+
+        unsafe {
+            CloseHandle(sei.hProcess).ok();
+        }
+
+        code
+    })
+    .await
+    .map_err(|e| CoreError::Io(std::io::Error::other(e)))?
+}
+
 #[cfg(not(windows))]
-pub async fn elevate_and_reexec(_args: &[String]) -> Result<(), CoreError> {
+#[tracing::instrument(skip_all, fields(exe = %_exe, timeout_secs = _timeout.as_secs()))]
+pub async fn spawn_elevated(
+    _exe: &str,
+    _args: &[String],
+    _timeout: Duration,
+) -> Result<i32, CoreError> {
     tracing::info!("elevation requested but not supported on this platform");
-    Err(CoreError::Io(std::io::Error::new(
-        std::io::ErrorKind::Unsupported,
-        "elevation is only supported on Windows",
-    )))
+    Err(CoreError::ElevationRequired)
 }

--- a/crates/astro-up-core/src/install/mod.rs
+++ b/crates/astro-up-core/src/install/mod.rs
@@ -90,17 +90,19 @@ impl InstallerService {
             }
         }
 
-        // Proactive elevation check
-        #[cfg(windows)]
-        if matches!(config.elevation, Some(Elevation::Required)) && !elevation::is_elevated() {
-            info!("proactive elevation required, re-executing");
-            let args: Vec<String> = std::env::args().collect();
-            elevation::elevate_and_reexec(&args).await?;
-            return Ok(InstallResult::Success { path: None });
-        }
+        // Proactive elevation: if the manifest declares elevation required and we
+        // are not already running as admin, we note this so the installer spawn
+        // path will use elevated execution. We do NOT re-exec the whole app.
+        let needs_elevation =
+            matches!(config.elevation, Some(Elevation::Required)) && !elevation::is_elevated();
+
         #[cfg(not(windows))]
-        if matches!(config.elevation, Some(Elevation::Required)) && !elevation::is_elevated() {
+        if needs_elevation {
             return Err(CoreError::ElevationRequired);
+        }
+
+        if needs_elevation {
+            info!("installer requires elevation — will launch with elevated privileges");
         }
 
         // upgrade_behavior = uninstall_previous
@@ -125,12 +127,13 @@ impl InstallerService {
         let result = if config.zip_wrapped {
             // Extract zip first, then run inner installer
             info!(package = %request.package_id, "zip_wrapped: extracting before install");
-            self.handle_zip_wrapped_install(request, config).await
+            self.handle_zip_wrapped_install(request, config, needs_elevation)
+                .await
         } else {
             match config.method {
                 InstallMethod::Zip => self.handle_zip_install(request).await,
                 InstallMethod::Portable => self.handle_portable_install(request).await,
-                _ => self.handle_exe_install(request).await,
+                _ => self.handle_exe_install(request, needs_elevation).await,
             }
         };
 
@@ -196,6 +199,7 @@ impl InstallerService {
     async fn handle_exe_install(
         &self,
         request: &InstallRequest,
+        needs_elevation: bool,
     ) -> Result<InstallResult, CoreError> {
         let config = &request.install_config;
         let (exe, args) = build_args(
@@ -206,7 +210,10 @@ impl InstallerService {
             &request.install_scope,
         );
 
-        let exit_code = if matches!(config.method, InstallMethod::Burn) {
+        let exit_code = if needs_elevation {
+            // Elevate just the installer process — not the entire app
+            elevation::spawn_elevated(&exe, &args, request.timeout).await?
+        } else if matches!(config.method, InstallMethod::Burn) {
             process::spawn_with_job_object(
                 &exe,
                 &args,
@@ -227,12 +234,34 @@ impl InstallerService {
                 Ok(InstallResult::SuccessRebootRequired { path: None })
             }
             ExitCodeOutcome::ElevationRequired => {
+                // Reactive elevation: the installer returned exit code 740 at
+                // runtime even though the manifest didn't declare elevation.
+                // Retry with elevated spawn instead of re-executing the app.
                 #[cfg(windows)]
                 {
-                    info!("reactive elevation (exit code 740), re-executing");
-                    let args_vec: Vec<String> = std::env::args().collect();
-                    elevation::elevate_and_reexec(&args_vec).await?;
-                    Ok(InstallResult::Success { path: None })
+                    info!("reactive elevation (exit code 740), retrying installer with elevation");
+                    let retry_code =
+                        elevation::spawn_elevated(&exe, &args, request.timeout).await?;
+                    let retry_outcome = interpret_exit_code(retry_code, config);
+                    match retry_outcome {
+                        ExitCodeOutcome::Success => Ok(InstallResult::Success { path: None }),
+                        ExitCodeOutcome::SuccessRebootRequired => {
+                            Ok(InstallResult::SuccessRebootRequired { path: None })
+                        }
+                        ExitCodeOutcome::ElevationRequired => Err(CoreError::ElevationRequired),
+                        ExitCodeOutcome::Failed { code, semantic } => {
+                            if let Some(known) = semantic {
+                                Err(CoreError::InstallerFailed {
+                                    exit_code: code,
+                                    response: known,
+                                })
+                            } else {
+                                Err(CoreError::Io(std::io::Error::other(format!(
+                                    "installer failed with exit code {code}"
+                                ))))
+                            }
+                        }
+                    }
                 }
                 #[cfg(not(windows))]
                 Err(CoreError::ElevationRequired)
@@ -274,6 +303,7 @@ impl InstallerService {
         &self,
         request: &InstallRequest,
         config: &InstallConfig,
+        needs_elevation: bool,
     ) -> Result<InstallResult, CoreError> {
         let temp_dir = std::env::temp_dir().join(format!(
             "astro-up-zip-{}",
@@ -343,13 +373,17 @@ impl InstallerService {
                     request.quiet,
                     &request.install_scope,
                 );
-                let exit_code = process::spawn_simple(
-                    &exe,
-                    &args,
-                    request.timeout,
-                    request.cancel_token.clone(),
-                )
-                .await?;
+                let exit_code = if needs_elevation {
+                    elevation::spawn_elevated(&exe, &args, request.timeout).await?
+                } else {
+                    process::spawn_simple(
+                        &exe,
+                        &args,
+                        request.timeout,
+                        request.cancel_token.clone(),
+                    )
+                    .await?
+                };
                 let outcome = interpret_exit_code(exit_code, config);
                 match outcome {
                     ExitCodeOutcome::Success => Ok(InstallResult::Success { path: None }),


### PR DESCRIPTION
## Summary
Replace app re-exec elevation with per-installer elevation.

- Windows 11 24H2+ (build >= 26100): uses built-in sudo command
- Older Windows: uses ShellExecuteW with runas verb via the windows crate
- OS version detected at runtime via registry CurrentBuildNumber
- Falls back to runas verb if version detection fails

Fixes #1024

## Test plan
- [ ] Install a package requiring elevation (synscan-app-ascom, ZWO drivers) on Win11 — verify UAC prompt for installer only
- [ ] Verify non-elevated packages still install normally
