### PR TITLE
perf(ci): replace sccache with Swatinem/rust-cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,14 +49,13 @@ jobs:
     if: needs.changes.outputs.crates == 'true'
     runs-on: ubuntu-latest
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
+      CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: rustfmt, clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - run: cargo fmt --all -- --check
       - run: cargo clippy -p astro-up-core -p astro-up-cli --all-targets -- -D warnings
@@ -90,14 +89,13 @@ jobs:
     if: needs.changes.outputs.crates == 'true'
     runs-on: windows-latest
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
+      CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: Create dummy sidecar for Tauri build.rs validation
         shell: bash
@@ -116,12 +114,11 @@ jobs:
     if: needs.changes.outputs.crates == 'true'
     runs-on: windows-latest
     env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
+      CARGO_INCREMENTAL: 0
     steps:
       - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
       - uses: taiki-e/install-action@nextest
       - name: Create dummy sidecar for Tauri build.rs validation
         shell: bash

--- a/.github/workflows/lifecycle-test.yml
+++ b/.github/workflows/lifecycle-test.yml
@@ -122,17 +122,16 @@ jobs:
             echo "source=build" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Install sccache
+      - name: Cache Rust build
         if: steps.cli.outputs.source == 'build'
-        uses: mozilla-actions/sccache-action@v0.0.9
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: astro-up
 
       - name: Build CLI (no release binary available)
         if: steps.cli.outputs.source == 'build'
         working-directory: astro-up
         shell: bash
-        env:
-          SCCACHE_GHA_ENABLED: "true"
-          RUSTC_WRAPPER: "sccache"
         run: |
           rustup default stable
           cargo build --release -p astro-up-cli

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,15 +78,12 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
     runs-on: windows-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: x86_64-pc-windows-msvc
-      - uses: mozilla-actions/sccache-action@v0.0.9
+      - uses: Swatinem/rust-cache@v2
 
       - uses: pnpm/action-setup@08c4be7e2e672a47d11bd04269e27e5f3e8529cb # v6.0.0
         with:


### PR DESCRIPTION
## Summary
Replace `mozilla-actions/sccache-action@v0.0.9` with `Swatinem/rust-cache@v2` across all workflows (ci.yml, release.yml, lifecycle-test.yml).

sccache was causing CI failures — orphan process kills, Node.js 20 deprecation warnings, and flaky build crashes. `Swatinem/rust-cache` caches `target/` and cargo registry without wrapping the compiler, so no RUSTC_WRAPPER needed.

## Test plan
- [ ] CI passes on this PR (proves rust-cache works)
- [ ] Download retry PR (#1032) should pass after rebasing onto this
