### PR TITLE
fix: remove phantom operation creation from package_started and download_started events

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -126,15 +126,16 @@ useCoreEvents((event: CoreEvent) => {
     const pct = Math.round((event.data.files_processed / event.data.total_files) * 100);
     updateProgress(pct, `Backing up: ${event.data.files_processed}/${event.data.total_files}`);
   } else if (event.type === "package_started") {
+    // User-initiated operations already call startOperation() in their view components.
+    // Only update the label here for queue mode (where the active package changes).
     if (queueActive.value) {
       const item = currentItem.value;
       const label = item ? `Updating ${item.packageName}` : `Updating ${event.data.package_id}`;
       startOperation(event.data.package_id, label);
     } else {
-      startOperation(event.data.package_id, `Installing ${event.data.package_id}`);
+      addStep("info", `Package: ${event.data.package_id}`);
     }
   } else if (event.type === "download_started") {
-    if (!isRunning.value) startOperation(event.data.id, `Downloading ${event.data.id}`);
     addStep("info", "Download started");
   } else if (event.type === "download_complete") {
     addStep("info", "Download complete");


### PR DESCRIPTION
## Summary
Two more event handlers in App.vue were creating phantom operations:

- `package_started` called `startOperation()` for non-queue operations — redundant since user views already call it
- `download_started` called `startOperation()` — triggered by catalog auto-refresh, creating a "Downloading" operation that never completes

Changed both to `addStep()` so they add progress info to existing operations instead of creating new ones. Queue mode (`package_started` with `queueActive`) still calls `startOperation` to update the label as packages rotate.

Follows up on #1027 which fixed only `scan_started`.

Fixes #1023

## Test plan
- [ ] Start the app, wait for catalog refresh, then click Update — no "operation in progress" error
- [ ] Update a package — verify progress steps still show in operations dock
- [ ] Update All (queue) — verify package labels still rotate correctly
