### PR TITLE
fix: skip update_available for unknown versions, add PE binary regex fallback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.32"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.30"
+version = "0.1.32"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.30"
+version = "0.1.32"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.30"
+version = "0.1.32"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/crates/astro-up-core/src/detect/pe.rs
+++ b/crates/astro-up-core/src/detect/pe.rs
@@ -75,9 +75,10 @@ pub async fn detect(
     }
 
     // Try each candidate path
+    let version_regex = config.version_regex.clone();
     let result = tokio::task::spawn_blocking(move || {
         for path in &candidates {
-            let result = read_pe_version(path);
+            let result = read_pe_version(path, version_regex.as_deref());
             match &result {
                 DetectionResult::Installed { .. }
                 | DetectionResult::InstalledUnknownVersion { .. } => return result,
@@ -96,7 +97,7 @@ pub async fn detect(
     }
 }
 
-fn read_pe_version(path: &str) -> DetectionResult {
+fn read_pe_version(path: &str, version_regex: Option<&str>) -> DetectionResult {
     trace!(method = "pe", %path, "reading PE file");
     let data = match std::fs::read(path) {
         Ok(d) => d,
@@ -119,23 +120,24 @@ fn read_pe_version(path: &str) -> DetectionResult {
     };
 
     let Ok(resources) = pe.resources() else {
-        return DetectionResult::InstalledUnknownVersion {
-            method: DetectionMethod::PeFile,
-            install_path: Some(path.to_string()),
-        };
+        return try_binary_regex(path, &data, version_regex);
     };
 
     let Ok(version_info) = resources.version_info() else {
-        return DetectionResult::InstalledUnknownVersion {
-            method: DetectionMethod::PeFile,
-            install_path: Some(path.to_string()),
-        };
+        return try_binary_regex(path, &data, version_regex);
     };
 
     // Prefer VS_FIXEDFILEINFO.dwFileVersion (binary, reliable)
     if let Some(fixed) = version_info.fixed() {
         let v = fixed.dwFileVersion;
         let version_str = format!("{}.{}.{}", v.Major, v.Minor, v.Patch);
+        // If the PE version looks like a placeholder (1.0.0, 0.0.0), try
+        // the binary regex before accepting it.
+        if is_placeholder_version(v.Major, v.Minor, v.Patch) {
+            if let Some(result) = search_binary_for_version(path, &data, version_regex) {
+                return result;
+            }
+        }
         return DetectionResult::Installed {
             version: Version::parse(&version_str),
             method: DetectionMethod::PeFile,
@@ -158,6 +160,55 @@ fn read_pe_version(path: &str) -> DetectionResult {
         }
     }
 
+    try_binary_regex(path, &data, version_regex)
+}
+
+/// Returns true if the PE version looks like a placeholder that the
+/// developer never bothered to update (e.g., 1.0.0, 0.0.0).
+fn is_placeholder_version(major: u16, minor: u16, patch: u16) -> bool {
+    (major <= 1 && minor == 0 && patch == 0) || (major == 0 && minor == 0)
+}
+
+/// Search the raw binary for a version string using a manifest-provided regex.
+/// Returns `Some(Installed)` if found, `None` otherwise.
+fn search_binary_for_version(
+    path: &str,
+    data: &[u8],
+    version_regex: Option<&str>,
+) -> Option<DetectionResult> {
+    let pattern = version_regex?;
+    let re = match regex::Regex::new(pattern) {
+        Ok(r) => r,
+        Err(e) => {
+            debug!(method = "pe", %pattern, error = %e, "invalid version_regex for binary search");
+            return None;
+        }
+    };
+
+    // Search ASCII content in the binary
+    let text = String::from_utf8_lossy(data);
+    let caps = re.captures(&text)?;
+    let version_str = caps.get(1)?.as_str();
+
+    debug!(
+        method = "pe",
+        %path,
+        version = %version_str,
+        "extracted version from binary via version_regex"
+    );
+
+    Some(DetectionResult::Installed {
+        version: Version::parse(version_str),
+        method: DetectionMethod::PeFile,
+        install_path: Some(path.to_string()),
+    })
+}
+
+/// When PE resources are unavailable, try the binary regex as last resort.
+fn try_binary_regex(path: &str, data: &[u8], version_regex: Option<&str>) -> DetectionResult {
+    if let Some(result) = search_binary_for_version(path, data, version_regex) {
+        return result;
+    }
     DetectionResult::InstalledUnknownVersion {
         method: DetectionMethod::PeFile,
         install_path: Some(path.to_string()),
@@ -166,5 +217,5 @@ fn read_pe_version(path: &str) -> DetectionResult {
 
 /// Synchronous version — useful for testing without a tokio runtime.
 pub fn read_pe_version_sync(path: &str) -> DetectionResult {
-    read_pe_version(path)
+    read_pe_version(path, None)
 }

--- a/crates/astro-up-gui/src/commands.rs
+++ b/crates/astro-up-gui/src/commands.rs
@@ -250,7 +250,7 @@ fn try_list_software(
                 .map(|ve| ve.version);
 
             let update_available = match (&installed_version, &latest_version) {
-                (Some(inst), Some(latest)) => {
+                (Some(inst), Some(latest)) if inst != "0.0.0" => {
                     let iv = astro_up_core::types::Version::parse(inst);
                     let lv = astro_up_core::types::Version::parse(latest);
                     lv > iv
@@ -372,6 +372,10 @@ pub async fn check_for_updates(state: State<'_, AppState>) -> Result<serde_json:
 
     for detection in &scan_result.results {
         if let DetectionResult::Installed { ref version, .. } = detection.result {
+            // Skip sentinel versions — can't meaningfully compare
+            if version.raw == "0.0.0" {
+                continue;
+            }
             let pkg_id = detection
                 .package_id
                 .parse()

--- a/frontend/src/views/DashboardView.vue
+++ b/frontend/src/views/DashboardView.vue
@@ -152,7 +152,7 @@ function confirmSingleUpdate() {
       </div>
       <div class="card updates-card">
         <div
-          v-for="pkg in updatablePackages.slice(0, 5)"
+          v-for="pkg in updatablePackages"
           :key="pkg.id"
           class="upd-row"
           @click="router.push({ name: 'package-detail', params: { id: pkg.id } })"


### PR DESCRIPTION
## Summary
- Skip `update_available` comparison when installed version is the `0.0.0` sentinel (version unknown)
- Add `version_regex` fallback to PE detection for binaries with placeholder PE versions
- Show all updates on Dashboard (remove `.slice(0, 5)` limit)

## What changed
- `commands.rs`: skip version comparison when `installed_version == "0.0.0"` in both `list_software` and `check_for_updates`
- `pe.rs`: when PE VersionInfo returns a placeholder (1.0.0/0.0.0) and `version_regex` is configured, search the raw binary for the version string
- `DashboardView.vue`: remove `.slice(0, 5)` to show all pending updates

## Test plan
- [x] All tests pass (clippy, fmt, cargo test)
- [ ] Deploy to .111 with ASTAP manifest `version_regex`, verify ASTAP shows `2026.04.10` instead of `1.0.0`
- [ ] Verify Dashboard shows all update entries without truncation
