### PR TITLE
fix: check token integrity level for elevation, treat E_ACCESSDENIED as elevation needed

### DIFF
--- a/crates/astro-up-core/src/install/elevation.rs
+++ b/crates/astro-up-core/src/install/elevation.rs
@@ -11,9 +11,10 @@ use crate::error::CoreError;
 pub fn is_elevated() -> bool {
     use windows::Win32::Security::TOKEN_QUERY;
     use windows::Win32::Security::{
-        GetTokenInformation, SECURITY_MANDATORY_HIGH_RID, TOKEN_MANDATORY_LABEL,
-        TokenIntegrityLevel,
+        GetTokenInformation, TOKEN_MANDATORY_LABEL, TokenIntegrityLevel,
     };
+    // SECURITY_MANDATORY_HIGH_RID = 0x2000 (not always exported by windows crate features)
+    const HIGH_INTEGRITY_RID: u32 = 0x2000;
     use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
 
     unsafe {
@@ -53,7 +54,7 @@ pub fn is_elevated() -> bool {
         }
         let rid =
             *windows::Win32::Security::GetSidSubAuthority(sid, (sub_authority_count - 1) as u32);
-        rid >= SECURITY_MANDATORY_HIGH_RID.0
+        rid >= HIGH_INTEGRITY_RID
     }
 }
 

--- a/crates/astro-up-core/src/install/elevation.rs
+++ b/crates/astro-up-core/src/install/elevation.rs
@@ -19,14 +19,25 @@ pub fn is_elevated() -> bool {
 
     unsafe {
         let mut token = windows::Win32::Foundation::HANDLE::default();
-        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_err() {
-            // Can't check — fall back to IsUserAnAdmin
+        if OpenProcessToken(
+            GetCurrentProcess(),
+            TOKEN_QUERY,
+            std::ptr::from_mut(&mut token),
+        )
+        .is_err()
+        {
             return windows::Win32::UI::Shell::IsUserAnAdmin().as_bool();
         }
 
-        // Query token integrity level
+        // Query token integrity level — first call gets required buffer size
         let mut size: u32 = 0;
-        let _ = GetTokenInformation(token, TokenIntegrityLevel, None, 0, &mut size);
+        let _ = GetTokenInformation(
+            token,
+            TokenIntegrityLevel,
+            None,
+            0,
+            std::ptr::from_mut(&mut size),
+        );
         if size == 0 {
             windows::Win32::Foundation::CloseHandle(token).ok();
             return windows::Win32::UI::Shell::IsUserAnAdmin().as_bool();
@@ -38,7 +49,7 @@ pub fn is_elevated() -> bool {
             TokenIntegrityLevel,
             Some(buffer.as_mut_ptr().cast()),
             size,
-            &mut size,
+            std::ptr::from_mut(&mut size),
         );
         windows::Win32::Foundation::CloseHandle(token).ok();
 
@@ -53,7 +64,7 @@ pub fn is_elevated() -> bool {
             return false;
         }
         let rid =
-            *windows::Win32::Security::GetSidSubAuthority(sid, (sub_authority_count - 1) as u32);
+            *windows::Win32::Security::GetSidSubAuthority(sid, u32::from(sub_authority_count - 1));
         rid >= HIGH_INTEGRITY_RID
     }
 }

--- a/crates/astro-up-core/src/install/elevation.rs
+++ b/crates/astro-up-core/src/install/elevation.rs
@@ -2,10 +2,59 @@ use std::time::Duration;
 
 use crate::error::CoreError;
 
-/// Checks if the current process is running with admin privileges.
+/// Checks if the current process has an elevated (high-integrity) token.
+///
+/// Uses the process token's integrity level rather than `IsUserAnAdmin()`,
+/// which can return `true` for admin-group users even when running with
+/// the limited (non-elevated) UAC token.
 #[cfg(windows)]
 pub fn is_elevated() -> bool {
-    unsafe { windows::Win32::UI::Shell::IsUserAnAdmin().as_bool() }
+    use windows::Win32::Security::TOKEN_QUERY;
+    use windows::Win32::Security::{
+        GetTokenInformation, SECURITY_MANDATORY_HIGH_RID, TOKEN_MANDATORY_LABEL,
+        TokenIntegrityLevel,
+    };
+    use windows::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+    unsafe {
+        let mut token = windows::Win32::Foundation::HANDLE::default();
+        if OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token).is_err() {
+            // Can't check — fall back to IsUserAnAdmin
+            return windows::Win32::UI::Shell::IsUserAnAdmin().as_bool();
+        }
+
+        // Query token integrity level
+        let mut size: u32 = 0;
+        let _ = GetTokenInformation(token, TokenIntegrityLevel, None, 0, &mut size);
+        if size == 0 {
+            windows::Win32::Foundation::CloseHandle(token).ok();
+            return windows::Win32::UI::Shell::IsUserAnAdmin().as_bool();
+        }
+
+        let mut buffer = vec![0u8; size as usize];
+        let ok = GetTokenInformation(
+            token,
+            TokenIntegrityLevel,
+            Some(buffer.as_mut_ptr().cast()),
+            size,
+            &mut size,
+        );
+        windows::Win32::Foundation::CloseHandle(token).ok();
+
+        if ok.is_err() {
+            return windows::Win32::UI::Shell::IsUserAnAdmin().as_bool();
+        }
+
+        let label: &TOKEN_MANDATORY_LABEL = &*(buffer.as_ptr().cast());
+        let sid = label.Label.Sid;
+        let sub_authority_count = *windows::Win32::Security::GetSidSubAuthorityCount(sid);
+        if sub_authority_count == 0 {
+            return false;
+        }
+        let rid =
+            *windows::Win32::Security::GetSidSubAuthority(sid, (sub_authority_count - 1) as u32);
+        rid >= SECURITY_MANDATORY_HIGH_RID.0
+    }
 }
 
 #[cfg(not(windows))]

--- a/crates/astro-up-core/src/install/elevation.rs
+++ b/crates/astro-up-core/src/install/elevation.rs
@@ -110,13 +110,30 @@ async fn spawn_elevated_sudo(
 
 /// Elevation via `ShellExecuteExW` with `runas` verb (pre-Win11 24H2).
 /// Shows a UAC prompt and waits for the elevated process to complete.
+///
+/// Uses `SW_SHOWNORMAL` instead of `SW_HIDE` because some installers
+/// (notably WiX Burn bootstrappers) rely on window messaging internally
+/// and fail when started hidden.
 #[cfg(windows)]
 async fn spawn_elevated_runas(
     exe: &str,
     args: &[String],
     timeout: Duration,
 ) -> Result<i32, CoreError> {
-    tracing::info!("using ShellExecuteExW runas for UAC elevation");
+    spawn_elevated_runas_inner(exe, args, timeout, false).await
+}
+
+/// Inner implementation shared between simple elevation and job-object elevation.
+/// When `with_job` is true, wraps the elevated process in a Windows Job Object
+/// for process tree tracking (needed for Burn bootstrappers).
+#[cfg(windows)]
+async fn spawn_elevated_runas_inner(
+    exe: &str,
+    args: &[String],
+    timeout: Duration,
+    with_job: bool,
+) -> Result<i32, CoreError> {
+    tracing::info!(with_job, "using ShellExecuteExW runas for UAC elevation");
 
     let exe_owned = exe.to_owned();
     let args_str = args.join(" ");
@@ -129,7 +146,7 @@ async fn spawn_elevated_runas(
         use windows::Win32::UI::Shell::{
             SEE_MASK_NOCLOSEPROCESS, SHELLEXECUTEINFOW, ShellExecuteExW,
         };
-        use windows::Win32::UI::WindowsAndMessaging::SW_HIDE;
+        use windows::Win32::UI::WindowsAndMessaging::SW_SHOWNORMAL;
         use windows::core::PCWSTR;
 
         let exe_wide = to_wide_null(&exe_owned);
@@ -142,7 +159,7 @@ async fn spawn_elevated_runas(
             lpVerb: PCWSTR(verb_wide.as_ptr()),
             lpFile: PCWSTR(exe_wide.as_ptr()),
             lpParameters: PCWSTR(args_wide.as_ptr()),
-            nShow: SW_HIDE.0,
+            nShow: SW_SHOWNORMAL.0,
             ..Default::default()
         };
 
@@ -156,6 +173,22 @@ async fn spawn_elevated_runas(
             tracing::warn!("ShellExecuteExW returned no process handle");
             return Err(CoreError::ElevationRequired);
         }
+
+        // Optionally wrap in a Job Object for process tree tracking.
+        // The process is already running, but child processes created after
+        // assignment will be contained. This is critical for Burn bootstrappers
+        // that spawn MSI child processes.
+        let job_handle = if with_job {
+            match create_and_assign_job(sei.hProcess) {
+                Ok(job) => Some(job),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to create job object for elevated process, continuing without");
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
         let wait = unsafe { WaitForSingleObject(sei.hProcess, timeout_ms) };
         let code = if wait.0 == 0 {
@@ -184,12 +217,91 @@ async fn spawn_elevated_runas(
 
         unsafe {
             CloseHandle(sei.hProcess).ok();
+            if let Some(job) = job_handle {
+                CloseHandle(job).ok();
+            }
         }
 
         code
     })
     .await
     .map_err(|e| CoreError::Io(std::io::Error::other(e)))?
+}
+
+/// Create a Job Object and assign the given process to it.
+/// Returns the job handle on success.
+#[cfg(windows)]
+fn create_and_assign_job(
+    process: windows::Win32::Foundation::HANDLE,
+) -> Result<windows::Win32::Foundation::HANDLE, CoreError> {
+    use windows::Win32::Foundation::CloseHandle;
+    use windows::Win32::System::JobObjects::{
+        AssignProcessToJobObject, CreateJobObjectW, JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE,
+        JOBOBJECT_EXTENDED_LIMIT_INFORMATION, JobObjectExtendedLimitInformation,
+        SetInformationJobObject,
+    };
+
+    let job = unsafe { CreateJobObjectW(None, None) }
+        .map_err(|e| CoreError::Io(std::io::Error::other(e)))?;
+
+    let mut info = JOBOBJECT_EXTENDED_LIMIT_INFORMATION::default();
+    info.BasicLimitInformation.LimitFlags = JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+    unsafe {
+        SetInformationJobObject(
+            job,
+            JobObjectExtendedLimitInformation,
+            (&raw const info).cast(),
+            std::mem::size_of_val(&info) as u32,
+        )
+    }
+    .map_err(|e| {
+        unsafe {
+            CloseHandle(job).ok();
+        }
+        CoreError::Io(std::io::Error::other(e))
+    })?;
+
+    unsafe { AssignProcessToJobObject(job, process) }.map_err(|e| {
+        unsafe {
+            CloseHandle(job).ok();
+        }
+        CoreError::Io(std::io::Error::other(e))
+    })?;
+
+    tracing::debug!("elevated process assigned to Job Object");
+    Ok(job)
+}
+
+/// Spawns an elevated process with Job Object tracking.
+///
+/// Combines UAC elevation with process tree management — needed for
+/// Burn bootstrappers and other installers that spawn child processes.
+#[cfg(windows)]
+#[tracing::instrument(skip_all, fields(exe = %exe, timeout_secs = timeout.as_secs()))]
+pub async fn spawn_elevated_with_job(
+    exe: &str,
+    args: &[String],
+    timeout: Duration,
+) -> Result<i32, CoreError> {
+    tracing::info!(args = ?args, "spawning elevated installer with job object");
+
+    if detect_sudo() {
+        // sudo.exe path already gives us proper process tracking via kill_on_drop
+        spawn_elevated_sudo(exe, args, timeout).await
+    } else {
+        spawn_elevated_runas_inner(exe, args, timeout, true).await
+    }
+}
+
+#[cfg(not(windows))]
+#[tracing::instrument(skip_all, fields(exe = %_exe, timeout_secs = _timeout.as_secs()))]
+pub async fn spawn_elevated_with_job(
+    _exe: &str,
+    _args: &[String],
+    _timeout: Duration,
+) -> Result<i32, CoreError> {
+    tracing::info!("elevated job object execution not supported on this platform");
+    Err(CoreError::ElevationRequired)
 }
 
 #[cfg(not(windows))]

--- a/crates/astro-up-core/src/install/exit_codes.rs
+++ b/crates/astro-up-core/src/install/exit_codes.rs
@@ -4,6 +4,9 @@ use crate::types::{InstallConfig, KnownExitCode};
 /// Well-known Windows exit codes with universal meaning.
 const EXIT_CODE_SUCCESS: i32 = 0;
 const EXIT_CODE_ELEVATION_REQUIRED: i32 = 740;
+/// HRESULT E_ACCESSDENIED (0x80070005) — Burn bootstrappers return this when
+/// they detect insufficient privileges. Treat the same as exit code 740.
+const EXIT_CODE_ACCESS_DENIED: i32 = -2_147_024_891; // 0x80070005 as i32
 const EXIT_CODE_REBOOT_REQUIRED: i32 = 3010;
 const EXIT_CODE_REBOOT_INITIATED: i32 = 1641;
 
@@ -41,7 +44,9 @@ pub fn interpret_exit_code(code: i32, config: &InstallConfig) -> ExitCodeOutcome
 
     // 4. Well-known Windows universal codes
     match code {
-        EXIT_CODE_ELEVATION_REQUIRED => ExitCodeOutcome::ElevationRequired,
+        EXIT_CODE_ELEVATION_REQUIRED | EXIT_CODE_ACCESS_DENIED => {
+            ExitCodeOutcome::ElevationRequired
+        }
         EXIT_CODE_REBOOT_REQUIRED | EXIT_CODE_REBOOT_INITIATED => {
             ExitCodeOutcome::SuccessRebootRequired
         }

--- a/crates/astro-up-core/src/install/mod.rs
+++ b/crates/astro-up-core/src/install/mod.rs
@@ -211,8 +211,12 @@ impl InstallerService {
             &request.install_scope,
         );
 
-        let exit_code = if needs_elevation {
-            // Elevate just the installer process — not the entire app
+        let exit_code = if needs_elevation && matches!(config.method, InstallMethod::Burn) {
+            // Burn bootstrappers spawn child processes (MSIs) — need job object
+            // tracking even when elevated, plus SW_SHOWNORMAL for window messaging.
+            elevation::spawn_elevated_with_job(&exe, &args, request.timeout).await?
+        } else if needs_elevation {
+            // Simple elevation for non-Burn installers
             elevation::spawn_elevated(&exe, &args, request.timeout).await?
         } else if matches!(config.method, InstallMethod::Burn) {
             process::spawn_with_job_object(
@@ -241,8 +245,11 @@ impl InstallerService {
                 #[cfg(windows)]
                 {
                     info!("reactive elevation (exit code 740), retrying installer with elevation");
-                    let retry_code =
-                        elevation::spawn_elevated(&exe, &args, request.timeout).await?;
+                    let retry_code = if matches!(config.method, InstallMethod::Burn) {
+                        elevation::spawn_elevated_with_job(&exe, &args, request.timeout).await?
+                    } else {
+                        elevation::spawn_elevated(&exe, &args, request.timeout).await?
+                    };
                     let retry_outcome = interpret_exit_code(retry_code, config);
                     match retry_outcome {
                         ExitCodeOutcome::Success => Ok(InstallResult::Success { path: None }),
@@ -374,7 +381,9 @@ impl InstallerService {
                     request.quiet,
                     &request.install_scope,
                 );
-                let exit_code = if needs_elevation {
+                let exit_code = if needs_elevation && matches!(config.method, InstallMethod::Burn) {
+                    elevation::spawn_elevated_with_job(&exe, &args, request.timeout).await?
+                } else if needs_elevation {
                     elevation::spawn_elevated(&exe, &args, request.timeout).await?
                 } else {
                     process::spawn_simple(


### PR DESCRIPTION
## Summary
- Fix the actual root cause of .NET Desktop Runtime install failure (exit code -2147024891 / 0x80070005 E_ACCESSDENIED)
- `IsUserAnAdmin()` returns true for admin-group users even with limited UAC token, so elevation was skipped entirely

## What changed
- `elevation.rs`: `is_elevated()` now checks the process token's integrity level (high-integrity = truly elevated) instead of `IsUserAnAdmin()` which lies about UAC-split tokens
- `exit_codes.rs`: HRESULT `0x80070005` (E_ACCESSDENIED) is now treated as `ElevationRequired`, triggering the reactive elevation retry — belt and suspenders

## Test plan
- [x] Clippy + tests pass
- [ ] Deploy to .111, trigger .NET Desktop Runtime update — should now properly elevate via UAC and succeed

Builds on #1041 (SW_SHOWNORMAL + job object for elevated Burn installs).
