### PR TITLE
fix: drop sudo.exe elevation, always use ShellExecuteExW runas

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -157,7 +157,7 @@ version = "0.1.35"
 
 [[package]]
 name = "astro-up-cli"
-version = "0.1.32"
+version = "0.1.35"
 dependencies = [
  "assert_cmd",
  "astro-up-core",
@@ -185,7 +185,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-core"
-version = "0.1.32"
+version = "0.1.35"
 dependencies = [
  "chrono",
  "directories",
@@ -224,7 +224,7 @@ dependencies = [
 
 [[package]]
 name = "astro-up-gui"
-version = "0.1.32"
+version = "0.1.35"
 dependencies = [
  "astro-up-core",
  "chrono",

--- a/crates/astro-up-core/src/install/elevation.rs
+++ b/crates/astro-up-core/src/install/elevation.rs
@@ -74,27 +74,6 @@ pub fn is_elevated() -> bool {
     false
 }
 
-/// Checks if `sudo.exe` is available on PATH (Windows 11 24H2+).
-#[cfg(windows)]
-pub fn detect_sudo() -> bool {
-    which_sudo().is_some()
-}
-
-#[cfg(not(windows))]
-pub fn detect_sudo() -> bool {
-    false
-}
-
-#[cfg(windows)]
-fn which_sudo() -> Option<std::path::PathBuf> {
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths).find_map(|dir| {
-            let candidate = dir.join("sudo.exe");
-            candidate.is_file().then_some(candidate)
-        })
-    })
-}
-
 /// Spawns an installer process with elevated (admin) privileges.
 ///
 /// Elevates only the installer process — the calling application continues
@@ -120,54 +99,7 @@ pub async fn spawn_elevated(
     spawn_elevated_runas(exe, args, timeout).await
 }
 
-/// Elevation via `sudo.exe` (Windows 11 24H2+). Inline elevation — no new window.
-#[cfg(windows)]
-async fn spawn_elevated_sudo(
-    exe: &str,
-    args: &[String],
-    timeout: Duration,
-) -> Result<i32, CoreError> {
-    use std::time::Instant;
-
-    tracing::info!("using sudo.exe for inline elevation");
-    let start = Instant::now();
-
-    let mut child = tokio::process::Command::new("sudo")
-        .arg(exe)
-        .args(args)
-        .kill_on_drop(true)
-        .spawn()
-        .map_err(|e| {
-            tracing::error!(error = %e, "failed to spawn sudo process");
-            CoreError::Io(e)
-        })?;
-
-    tokio::select! {
-        result = child.wait() => {
-            let status = result?;
-            let code = status.code().unwrap_or(-1);
-            tracing::info!(
-                exit_code = code,
-                duration_ms = start.elapsed().as_millis() as u64,
-                "elevated installer process exited"
-            );
-            Ok(code)
-        }
-        () = tokio::time::sleep(timeout) => {
-            if let Err(e) = child.kill().await {
-                tracing::trace!(error = %e, "failed to kill elevated process during timeout");
-            }
-            tracing::warn!(
-                timeout_secs = timeout.as_secs(),
-                duration_ms = start.elapsed().as_millis() as u64,
-                "elevated installer process timed out"
-            );
-            Err(CoreError::InstallerTimeout { timeout_secs: timeout.as_secs() })
-        }
-    }
-}
-
-/// Elevation via `ShellExecuteExW` with `runas` verb (pre-Win11 24H2).
+/// Elevation via `ShellExecuteExW` with `runas` verb.
 /// Shows a UAC prompt and waits for the elevated process to complete.
 ///
 /// Uses `SW_SHOWNORMAL` instead of `SW_HIDE` because some installers

--- a/crates/astro-up-core/src/install/elevation.rs
+++ b/crates/astro-up-core/src/install/elevation.rs
@@ -102,8 +102,11 @@ fn which_sudo() -> Option<std::path::PathBuf> {
 /// restart the GUI in Tauri.
 ///
 /// Strategy:
-/// 1. If `sudo.exe` is on PATH (Windows 11 24H2+), prefix the command with `sudo`.
-/// 2. Otherwise, use `ShellExecuteExW` with the `runas` verb to trigger a UAC prompt.
+/// Uses `ShellExecuteExW` with the `runas` verb to trigger a UAC prompt.
+///
+/// Note: `sudo.exe` (Windows 11 24H2+) was previously preferred but its inline
+/// mode does not grant full admin rights to GUI installers with embedded admin
+/// manifests — both .NET and ZWO installers returned E_ACCESSDENIED via sudo.
 ///
 /// Returns the installer process exit code.
 #[cfg(windows)]
@@ -114,12 +117,7 @@ pub async fn spawn_elevated(
     timeout: Duration,
 ) -> Result<i32, CoreError> {
     tracing::info!(args = ?args, "spawning installer with elevation");
-
-    if detect_sudo() {
-        spawn_elevated_sudo(exe, args, timeout).await
-    } else {
-        spawn_elevated_runas(exe, args, timeout).await
-    }
+    spawn_elevated_runas(exe, args, timeout).await
 }
 
 /// Elevation via `sudo.exe` (Windows 11 24H2+). Inline elevation — no new window.
@@ -345,13 +343,7 @@ pub async fn spawn_elevated_with_job(
     timeout: Duration,
 ) -> Result<i32, CoreError> {
     tracing::info!(args = ?args, "spawning elevated installer with job object");
-
-    if detect_sudo() {
-        // sudo.exe path already gives us proper process tracking via kill_on_drop
-        spawn_elevated_sudo(exe, args, timeout).await
-    } else {
-        spawn_elevated_runas_inner(exe, args, timeout, true).await
-    }
+    spawn_elevated_runas_inner(exe, args, timeout, true).await
 }
 
 #[cfg(not(windows))]


### PR DESCRIPTION
## Summary
Drop `sudo.exe` elevation path — it doesn't grant full admin rights to GUI installers with embedded admin manifests. Always use `ShellExecuteExW runas` which reliably triggers UAC.

## Root cause
`sudo.exe` inline mode on Windows 11 returned `E_ACCESSDENIED` (0x80070005) for both .NET Desktop Runtime (Burn) and ZWO ASI Driver (NSIS). The UAC prompt never appeared — sudo ran the installer but without actual elevation.

## Test plan
- [x] Clippy + tests pass
- [ ] Deploy to .111, install ZWO ASI Driver — should show UAC prompt and succeed
- [ ] Deploy to .111, install .NET Desktop Runtime — same
