### PR TITLE
docs: rewrite all pages for current app state (v0.1.36)

### DIFF
--- a/docs/guide/adding-manifests.md
+++ b/docs/guide/adding-manifests.md
@@ -1,62 +1,140 @@
 # Adding Manifests
 
-Software packages are defined as TOML manifests in the [astro-up-manifests](https://github.com/nightwatch-astro/astro-up-manifests) repository. Here's how to add a new package.
+Software packages are defined as TOML manifests in the [astro-up-manifests](https://github.com/nightwatch-astro/astro-up-manifests) repository.
 
 ## Steps
 
 1. Fork the [manifests repo](https://github.com/nightwatch-astro/astro-up-manifests)
-2. Create a new file in `manifests/` named `<package-id>.toml` (e.g., `nina-app.toml`)
-3. Fill in the manifest fields (see template below)
-4. Add a package icon to `assets/icons/<package-id>.png` (128x128 PNG, transparent background). If no official icon is available, use a placeholder — but the file must exist.
-5. Submit a pull request
+2. Create `manifests/<package-id>.toml` (e.g., `nina-app.toml`)
+3. Add a package icon to `assets/icons/<package-id>.png` (128x128 PNG, transparent background)
+4. Submit a pull request
 
-## Manifest Template
+## Complete Example
 
 ```toml
-[package]
-id = "my-package"
-name = "My Package"
+id = "nina-app"
+name = "N.I.N.A."
+slug = "nina"
+type = "application"
 category = "capture"
-publisher = "Publisher Name"
-website = "https://example.com"
-description = "Short description of the software."
-license = "MIT"
-
-[checkver]
-# How to discover the latest version
-github = "owner/repo"
-# Or: url = "https://example.com/download"
-#     regex = "Version ([\\d.]+)"
-
-[autoupdate]
-url = "https://example.com/downloads/my-package-$version-setup.exe"
+publisher = "N.I.N.A. Team"
+homepage = "https://nighttime-imaging.eu"
+description = "Nighttime Imaging 'N' Astronomy — advanced capture sequencer."
+license = "MPL-2.0"
+aliases = ["NINA", "Nighttime Imaging"]
+tags = ["capture", "sequencer", "imaging"]
 
 [install]
 method = "inno_setup"
-quiet_args = ["/VERYSILENT", "/NORESTART", "/SUPPRESSMSGBOXES"]
-interactive_args = ["/NORESTART"]
+scope = "user"
+elevation = "required"
+zip_wrapped = false
+upgrade_behavior = "install"
+timeout = "10m"
+
+[install.switches]
+silent = ["/VERYSILENT", "/NORESTART", "/SUPPRESSMSGBOXES"]
+interactive = ["/NORESTART"]
+log = "/LOG=$TEMP\\nina-install.log"
+
+[install.known_exit_codes]
+"1" = "package_in_use"
+"5" = "cancelled_by_user"
+"3010" = "reboot_required"
 
 [detection]
-method = "Registry"
-registry_key = "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\My Package_is1"
+method = "registry"
+registry_key = "HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\NINA 2_is1"
 registry_value = "DisplayVersion"
+
+[detection.fallback]
+method = "pe_file"
+file_path = "$PROGRAMFILES\\NINA\\NINA.exe"
+version_regex = "^(\\d+\\.\\d+\\.\\d+)"
+
+[checkver]
+provider = "github"
+github = "nightwatch-astro/nina"
+asset_pattern = "NINA-.*-setup\\.exe$"
+
+[checkver.autoupdate]
+url = "https://github.com/nightwatch-astro/nina/releases/download/v$version/NINA-$version-setup.exe"
+
+[dependencies]
+requires = [{ id = "dotnet-desktop-runtime", min_version = "8.0" }]
+optional = ["ascom-platform"]
+
+[hardware]
+vid_pid = []
+device_class = "Camera"
 
 [backup]
 config_paths = [
-  "$LOCALAPPDATA/MyPackage/settings.json",
-  "$LOCALAPPDATA/MyPackage/profiles/",
+  "$LOCALAPPDATA/NINA/Profiles/",
+  "$LOCALAPPDATA/NINA/EquipmentProfiles/",
+  "$LOCALAPPDATA/NINA/Sequence/",
 ]
 ```
 
-## Finding Information
+## Field Reference
 
-- **Install method**: Run the installer with `/?` to see flags. See the [Silent Installers Guide](./silent-installers.md).
-- **Registry key**: Install the software, then check `regedit` under `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`.
-- **Detection config**: You can skip this — the [lifecycle testing workflow](./lifecycle-testing.md) discovers detection configs automatically by installing on a Windows runner.
+### Top-level
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `id` | yes | Package ID (`vendor-product` convention, lowercase, hyphens only) |
+| `name` | yes | Display name |
+| `slug` | yes | URL-friendly short name |
+| `type` | yes | `application`, `driver`, `runtime`, `database`, `usb_driver`, `resource` |
+| `category` | yes | `capture`, `guiding`, `platesolving`, `equipment`, `focusing`, `planetarium`, `viewers`, `prerequisites`, `usb`, `driver` |
+| `publisher` | no | Developer or organization |
+| `homepage` | no | Official project URL |
+| `description` | no | Short description |
+| `license` | no | SPDX license identifier |
+| `aliases` | no | Alternative names (used in search) |
+| `tags` | no | Searchable tags |
+
+### `[install]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | `exe`, `msi`, `inno_setup`, `nsis`, `wix`, `burn`, `zip`, `portable`, `download_only` |
+| `scope` | string | `machine`, `user`, `either` |
+| `elevation` | string | `required` (UAC via astro-up), `prohibited` (no elevation), `self` (installer handles UAC) |
+| `zip_wrapped` | bool | Download is a zip containing the actual installer |
+| `zip_inner_path` | string | Subfolder inside zip where installer lives (e.g., `"x64"`) |
+| `upgrade_behavior` | string | `install` (over-install), `uninstall_previous`, `deny` |
+| `timeout` | duration | Installer timeout override (default 10m, range 10s--3600s) |
+| `switches.silent` | string[] | Silent install arguments |
+| `switches.interactive` | string[] | Interactive install arguments |
+| `switches.log` | string | Log file path template |
+| `switches.install_dir` | string | Install location argument |
+| `known_exit_codes` | map | Exit code to meaning: `package_in_use`, `reboot_required`, `cancelled_by_user`, `already_installed`, `missing_dependency`, `disk_full` |
+| `success_codes` | int[] | Non-zero exit codes that mean success |
+
+### `[detection]`
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `method` | string | `registry`, `pe_file`, `wmi`, `wmi_apps`, `driver_store`, `ascom_profile`, `file_exists`, `config_file`, `ledger` |
+| `registry_key` | string | Full registry key path |
+| `registry_value` | string | Registry value name (e.g., `DisplayVersion`) |
+| `file_path` | string | Path to executable or config file |
+| `version_regex` | string | Regex to extract version from detected string |
+| `product_code` | string | MSI product GUID |
+| `upgrade_code` | string | MSI upgrade GUID |
+| `inf_provider` | string | Driver INF provider name (for driver_store) |
+| `device_class` | string | Driver device class |
+| `inf_name` | string | Driver INF filename |
+| `fallback` | object | Another `[detection]` config tried if primary fails |
+
+### `[checkver]` / `[dependencies]` / `[hardware]` / `[backup]`
+
+See the [complete example](#complete-example) above. Detection configs are optional -- the [lifecycle testing workflow](./lifecycle-testing.md) discovers them automatically by installing on a Windows runner and probing for detection signatures.
 
 ## Tips
 
-- Use the `vendor-product` naming convention for IDs (e.g., `zwo-asi-camera-driver`)
-- Every package must have an icon in `assets/icons/<package-id>.png` — the GUI uses it in the catalog and detail views
-- Test your manifest locally before submitting: `astro-up install my-package --dry-run`
-- Detection configs are validated against the actual install by CI
+- Use `vendor-product` naming: `zwo-asi-camera-driver`, `ascom-platform`
+- Every package needs an icon at `assets/icons/<package-id>.png`
+- Test locally: `astro-up install my-package --dry-run`
+- Detection configs are validated by CI lifecycle tests

--- a/docs/guide/backup.md
+++ b/docs/guide/backup.md
@@ -15,36 +15,33 @@ Open a package's detail page and click **Backup**, or use the **Backup** view fo
 astro-up backup nina-app
 
 # List available backups
-astro-up backup --list
+astro-up show backups
+
+# Restore from backup
+astro-up restore nina-app
 ```
 
 ## What Gets Backed Up
 
-Backups capture application configuration files and settings directories. The catalog defines which paths to include for each package (e.g., `%LOCALAPPDATA%\NINA\` for N.I.N.A.).
-
-Backups are stored as compressed archives in the backup directory.
+Backups capture application configuration files and settings directories. The catalog defines which paths to include for each package (e.g., `%LOCALAPPDATA%\NINA\` for N.I.N.A.). Backups are stored as compressed archives.
 
 ## Restoring
 
-```sh
-astro-up restore nina-app
-```
-
-In the GUI, use the **Quick Restore** panel in the Backup view to select an application and backup version.
-
-## Backup Policy
-
-Configure automatic backup behavior in **Settings > Backup** (GUI) or the `[backup_policy]` section of `config.toml`:
-
-| Setting | Default | Description |
-|---------|---------|-------------|
-| Scheduled backups | Off | Run backups on a schedule (daily/weekly/monthly) |
-| Max per package | 5 | Keep at most N backups per package |
-| Max total size | 0 (unlimited) | Total backup storage limit in MB |
-| Max age | 0 (never) | Auto-delete backups older than N days |
-
-All backup settings are configurable from the GUI Settings panel, the CLI, or the [configuration file](/reference/config).
+From the CLI, run `astro-up restore <package>`. In the GUI, use the **Quick Restore** panel in the Backup view to select a package and backup version.
 
 ## Pre-Update Backups
 
-When updating a package, Astro-Up automatically backs up configuration before running the new installer. The install path is resolved from the detection result's `install_path` field, ensuring backup paths match the actual install location.
+When updating a package, Astro-Up automatically backs up configuration before running the new installer. The backup path is resolved from the detection result's `install_path`, ensuring it matches the actual install location.
+
+## Backup Policy
+
+Configure in **Settings > Backup** (GUI) or the `backup_policy` config section:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `scheduled` | Off | Run backups on a schedule |
+| `max_per_package` | 5 | Keep at most N backups per package |
+| `max_total_size_mb` | 0 (unlimited) | Total backup storage limit in MB |
+| `max_age_days` | 0 (never) | Auto-delete backups older than N days |
+
+All backup settings are configurable from the GUI Settings panel, the CLI, or the [configuration file](/reference/config).

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,43 +1,56 @@
 # Configuration
 
-Astro-Up uses a layered TOML configuration system with sensible defaults. **Every setting is configurable from the GUI, CLI, or config file** — choose whichever you prefer.
+Astro-Up uses a layered configuration system stored in SQLite. Every setting is configurable from the GUI, CLI, or config file.
 
 ## GUI Settings
 
-Open **Settings** from the sidebar to access all configuration options organized by category: General, Catalog, Network, Backup, Notifications, and Logging.
+Open **Settings** from the sidebar. Options are organized by category.
 
-## Config File
-
-The config file is at:
-
-```
-%APPDATA%\nightwatch\astro-up\config.toml
-```
-
-It's created automatically on first run. Edit it directly or via:
+## CLI
 
 ```sh
-astro-up config --edit
+# Show current configuration
+astro-up config show
+
+# Initialize config with defaults
+astro-up config init
 ```
 
-## CLI Overrides
-
-Most settings can be overridden per-command:
-
-```sh
-astro-up --log-level debug scan
-astro-up --config C:\path\to\config.toml list
-```
-
-## Quick Reference
+## Config Sections
 
 | Section | Key settings |
 |---------|-------------|
-| **General** | Font size, install scope, install method, auto-scan, auto-update |
-| **Catalog** | Catalog URL, cache TTL |
-| **Network** | Proxy, timeouts, speed limit |
-| **Backup** | Schedule, retention limits |
-| **Notifications** | Enable/disable, display duration, per-type toggles |
-| **Logging** | Log level, file logging |
+| **ui** | `theme`, `font_size`, `scan_interval`, `default_install_scope`, `default_install_method` |
+| **startup** | `start_at_login`, `start_minimized`, `minimize_to_tray` |
+| **catalog** | `url`, `cache_ttl` |
+| **network** | `proxy`, `timeouts`, `speed_limit` |
+| **backup_policy** | `scheduled`, `max_per_package`, `max_total_size_mb`, `max_age_days` |
+| **notifications** | `enabled`, plus granular per-type toggles |
+| **logging** | `level`, `log_to_file`, `max_age_days` |
+| **paths** | `download_dir`, `cache_dir`, `portable_apps_dir`, `keep_installers`, `purge_installers_after_days` |
+
+## Paths
+
+Default data location:
+
+```
+%APPDATA%\nightwatch\astro-up\
+```
+
+Key directories:
+
+| Path | Purpose |
+|------|---------|
+| Database | SQLite database with catalog, config, and ledger |
+| `download_dir` | Downloaded installers (configurable) |
+| `cache_dir` | Catalog cache |
+| `portable_apps_dir` | Extracted portable applications with Windows shortcuts |
+
+## Notable Settings
+
+- **`portable_apps_dir`** -- where portable apps are extracted; Astro-Up creates a Windows shortcut for each
+- **`keep_installers`** / **`purge_installers_after_days`** -- control whether downloaded installers are kept or cleaned up automatically
+- **`speed_limit`** -- cap download bandwidth to avoid saturating your connection
+- **`scan_interval`** -- how often the GUI checks for installed software automatically
 
 For the complete field reference, see [Configuration File Reference](/reference/config).

--- a/docs/guide/detection.md
+++ b/docs/guide/detection.md
@@ -1,37 +1,32 @@
 # Detection
 
-Astro-Up automatically detects installed astrophotography software using multiple strategies, ordered by reliability.
+Astro-Up automatically detects installed astrophotography software using 9 detection methods, ordered by reliability.
 
 ## Detection Methods
 
-| Method | Use case | Fields used |
-|--------|----------|-------------|
+| Method | Use case | Key fields |
+|--------|----------|------------|
 | **Registry** | Most installed apps | `registry_key`, `registry_value` |
-| **PeFile** | Apps with versioned executables | `file_path` |
+| **PeFile** | Apps with versioned executables | `file_path`; optional `version_regex` for binary string extraction |
 | **FileExists** | Portable apps, data files | `file_path` |
-| **ConfigFile** | Apps with version in config | `file_path`, `version_regex` |
+| **ConfigFile** | Apps with version in config files | `file_path`, `version_regex` |
 | **AscomProfile** | ASCOM drivers | Device type + ProgID |
 | **Wmi** | USB/hardware drivers | `driver_provider`, `device_class`, `inf_name` |
 | **DriverStore** | Driver packages | INF name |
-| **MSI** | MSI-installed packages | `product_code`, `upgrade_code` |
+| **WmiApps** | Win32_InstalledWin32Program matching | Name pattern matching |
+| **Ledger** | Manual tracking only | Recorded from previous installs |
 
-### Windows Registry
+### Registry
 
-The primary detection method. Astro-Up scans:
-
-- `HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`
-- `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall`
-- Application-specific keys defined in the catalog
-
-Registry entries provide the installed version, install path, and uninstall command.
+The primary detection method. Astro-Up scans the standard uninstall keys (`HKLM` and `HKCU`) plus application-specific registry keys defined in the catalog. Registry entries provide the installed version, install path, and uninstall command.
 
 ### PE Header Analysis
 
-For software without clean registry entries, Astro-Up reads PE (Portable Executable) headers from known install locations to extract `FileVersion` and `ProductVersion` from the `VS_FIXEDFILEINFO` resource.
+For software without clean registry entries, Astro-Up reads PE (Portable Executable) headers from known install locations to extract `FileVersion` and `ProductVersion`. Some applications (e.g., ASTAP) embed placeholder PE versions -- for these, Astro-Up falls back to `version_regex` to extract the real version from binary strings in the executable.
 
 ### Fallback Chains
 
-Detection configs support a `fallback` field — if the primary method doesn't find the package, the fallback method is tried. This handles cases where the same software installs differently depending on method (MSI vs EXE vs ZIP).
+Detection configs support a `fallback` field. If the primary method does not find the package, the fallback method is tried. This handles cases where the same software installs differently depending on method (MSI vs EXE vs ZIP).
 
 ## How Scanning Works
 
@@ -43,7 +38,7 @@ Detection configs support a `fallback` field — if the primary method doesn't f
 
 ## Scan Triggers
 
-- **GUI**: automatic on launch (if enabled), or via the Installed view's refresh button
+- **GUI**: automatic on launch (configurable), or via the **Installed** view refresh button
 - **CLI**: `astro-up scan`
 
 ## Detection Status
@@ -53,8 +48,4 @@ Detection configs support a `fallback` field — if the primary method doesn't f
 | **Installed** | Found and up to date |
 | **Update Available** | Installed but newer version exists |
 | **Not Installed** | Not found on system |
-| **Acknowledged** | Manually marked as known |
-
-## Populating Detection Configs
-
-Detection configs are discovered automatically by the [lifecycle testing workflow](./lifecycle-testing.md), which installs each package on a Windows runner and probes for detection signatures.
+| **Acknowledged** | Manually marked as known (via Ledger) |

--- a/docs/guide/how-it-works.md
+++ b/docs/guide/how-it-works.md
@@ -1,62 +1,68 @@
 # How It Works
 
-Under the hood — catalog management, version checking, caching, and the update pipeline.
-
-## Manifest Catalog
-
-Software definitions (manifests) are maintained in a [separate repository](https://github.com/nightwatch-astro/astro-up-manifests) and compiled into a SQLite database (`catalog.db`). Your Astro-Up installation fetches this file at runtime — you get the latest catalog without updating the app itself.
-
-### Caching
-
-To keep things fast and minimize bandwidth:
-
-- **Disk cache** — `catalog.db` is persisted locally between sessions
-- **TTL validation** — re-syncs only when the cache is stale (configurable, default 12h)
-- **ETag support** — conditional requests avoid re-downloading unchanged data
-- **Force sync** — `astro-up sync --force` or the Re-download button in Settings
-
-### Signature Verification
-
-The catalog is signed with [minisign](https://jedisct1.github.io/minisign/). Astro-Up verifies signatures before trusting fetched data, protecting against tampered manifests.
-
-## Update Flow
-
-When you update a package:
+## Manifest Pipeline
 
 ```
-1. Check catalog for latest version
-2. Compare against locally detected version
-3. If newer: download installer (SHA-256 verified)
-4. Back up configuration (profiles, settings, equipment configs)
-5. Run installer (silently by default)
-6. Re-run detection to verify new version
-7. Record install path in ledger for future backups
+Version checker (CI) scrapes latest versions from GitHub/GitLab/vendor sites
+  -> Compiler reads TOML manifests + discovered versions
+  -> Builds catalog.db (SQLite with FTS5 search)
+  -> Signs with minisign
+  -> Published as GitHub Release artifact
 ```
+
+Astro-Up fetches `catalog.db` at runtime with ETag caching and configurable TTL. You get new packages and versions without updating the app.
 
 ## Detection Pipeline
 
-Detection uses 7 methods (Registry, PE, FileExists, ConfigFile, ASCOM, WMI, DriverStore) with fallback chains. See [Detection](./detection.md) for details.
+Detection runs in two phases:
 
-New detection configs are discovered automatically by the [lifecycle testing workflow](./lifecycle-testing.md), which installs packages on Windows runners and probes for detection signatures.
+1. **WMI enumeration** -- bulk query `Win32_Product` and `Win32_InstalledWin32Program` to find installed software
+2. **Per-package chain** -- for each catalog package, try methods in order with fallback:
+
+| Method | Source | Used for |
+|--------|--------|----------|
+| `registry` | Windows Registry `Uninstall` keys | Most applications |
+| `pe_file` | PE header version info from EXE on disk | Portable apps, version validation |
+| `wmi` / `wmi_apps` | WMI queries by name or product code | Apps without registry entries |
+| `driver_store` | Driver store by INF provider/class | Device drivers |
+| `ascom_profile` | ASCOM Profile COM interface | ASCOM drivers |
+| `file_exists` | Check if file exists at known path | Simple presence detection |
+| `config_file` | Parse version from config/settings file | Apps that store version in config |
+| `ledger` | Astro-Up's own install ledger | Download-only packages |
+
+Each detection config can have a `fallback` pointing to another detection config, forming a chain.
+
+## Install Pipeline
+
+```
+1. Plan       -- resolve target version, check constraints
+2. Process    -- check if software is running (abort if blocking)
+3. Disk       -- check available disk space
+4. Asset      -- select download asset (prompt if multiple options)
+5. Download   -- fetch installer (SHA-256 verified, resumable)
+6. Backup     -- save config files (if backup config exists)
+7. Install    -- run installer with elevation if required
+8. Verify     -- re-detect to confirm new version
+9. Ledger     -- record install path and version
+```
+
+Events are emitted at each step, driving progress display in both GUI and CLI.
+
+Elevation is handled per-package: `required` elevates via `ShellExecuteEx` with `runas`, `self` lets the installer handle its own UAC, `prohibited` runs without elevation.
 
 ## Data Flow
 
+Both GUI (Tauri v2 + Vue 3) and CLI (clap + ratatui) share `astro-up-core`:
+
 ```
-User Action (GUI or CLI)
-  -> Engine (orchestration, dependency resolution)
-    -> Catalog (manifest lookup, version comparison)
-    -> Detect (scan local system)
-    -> Download (fetch installer, verify checksum)
-    -> Backup (save config)
-    -> Install (run installer, verify detection)
-    -> Ledger (record install path)
+User action (GUI command or CLI subcommand)
+  -> Orchestrator (pipeline coordinator, operation lock)
+    -> Catalog reader (SQLite, FTS5 search)
+    -> Scanner (detection chain per package)
+    -> Downloader (resumable, SHA-256 verified)
+    -> Backup manager (zip config files)
+    -> Installer (method-specific, elevation-aware)
+    -> History (operations table in SQLite)
 ```
 
-## GUI vs CLI
-
-Both interfaces share the same `astro-up-core` library:
-
-- **No arguments** -> launches the GUI (Tauri v2 + Vue 3)
-- **Any subcommand** (e.g., `list`, `check`, `update`) -> runs the CLI (clap)
-
-The engine, catalog, detection, download, and install logic is identical in both paths.
+The orchestrator acquires a global file lock to prevent concurrent operations. Operation history is recorded in the `operations` table for the GUI's operation history view.

--- a/docs/guide/installing.md
+++ b/docs/guide/installing.md
@@ -6,64 +6,64 @@
 
 1. Navigate to **Catalog** and find the package
 2. Click the package to open its detail page
-3. Click **Install** — Astro-Up downloads, verifies, and runs the installer
+3. Click **Install** -- Astro-Up downloads, verifies, and runs the installer
+4. For packages with multiple assets (e.g., 32-bit vs 64-bit), an asset selection dialog appears
 
 ### From the CLI
 
 ```sh
-# Install a specific package
+# Install a package
 astro-up install nina-app
 
-# Install with interactive installer (shows installer UI)
-astro-up install nina-app --interactive
+# Force reinstall an already-installed package
+astro-up install nina-app --force
 ```
 
 ## Install Pipeline
 
 Each install goes through these steps:
 
-1. **Plan** — resolve dependencies and determine install order
-2. **Download** — fetch the installer with progress tracking and SHA-256 verification
-3. **Backup** — optionally back up existing settings (if already installed)
-4. **Execute** — run the installer (silent by default)
-5. **Verify** — run detection to confirm the package is installed
-6. **Record** — store install path in the ledger for future backup/uninstall
+1. **Download** -- fetch the installer with progress tracking and SHA-256 verification
+2. **Backup** -- back up existing settings if the package is already installed
+3. **Elevate** -- request administrator privileges via UAC if needed
+4. **Execute** -- run the installer silently by default
+5. **Verify** -- run detection to confirm the package is installed
+6. **Record** -- store install path in the ledger for future backup/updates
 
 ## Updating
 
-### Check for Updates
-
 ```sh
-# Check all installed packages
-astro-up check
-
 # Update a specific package
 astro-up update nina-app
 
-# Update all
+# Update all outdated packages (queued sequentially)
 astro-up update --all
 ```
 
-### GUI
-
-The **Installed** view shows an update badge next to packages with newer versions. Click **Update** on the detail page to start the update pipeline.
+In the GUI, the **Installed** view shows an update badge next to outdated packages. Click **Update** on the detail page, or update multiple packages -- they queue and run sequentially.
 
 ## Supported Install Methods
 
 | Method | Description |
 |--------|-------------|
+| `exe` | Generic EXE with custom silent args |
+| `msi` | Windows Installer (`/qn /norestart`) |
 | `inno_setup` | InnoSetup installers (`/VERYSILENT /NORESTART`) |
 | `nsis` | NSIS installers (`/S`) |
-| `msi` | Windows Installer (`/qn /norestart`) |
-| `exe` | Generic EXE with custom silent args |
-| `zip` | Extract to target directory |
-| `zip_wrap` | ZIP containing an installer |
-| `download_only` | Download without install (manual) |
-| `portable` | Single binary, no install needed |
+| `wix` | WiX-based installers |
+| `burn` | WiX Burn bootstrappers (with Job Object process tree tracking) |
+| `zip` | Extract to target directory (supports `zip_wrapped` inner installers) |
+| `portable` | Extract and create a Windows shortcut in the portable apps folder |
+| `download_only` | Download to the portable apps directory without running an installer |
 
-## Silent vs Interactive
+## Elevation (UAC)
 
-By default, installers run silently (no UI). Change the default in **Settings > General > Install Method**, or use `--interactive` on the CLI.
+Astro-Up handles Windows administrator privileges automatically:
+
+- **Proactive** -- if the manifest declares elevation is required, UAC is requested upfront
+- **Reactive** -- if an installer returns exit code 740 or `E_ACCESSDENIED`, Astro-Up retries with elevation
+
+Elevation uses `ShellExecuteExW runas` for standard UAC prompts.
 
 ## Download Management
 

--- a/docs/guide/quick-start.md
+++ b/docs/guide/quick-start.md
@@ -6,8 +6,10 @@ Launch Astro-Up from the Start Menu or system tray. On first run:
 
 1. The catalog syncs automatically
 2. Navigate to **Catalog** to browse available software
-3. Switch to **Installed** to see what's already on your system
+3. Switch to **Installed** to see what is already on your system
 4. Click any package for details, version history, and install options
+
+The **Dashboard** gives an overview of installed software, available updates, and recent activity. The **Settings** view lets you configure all options.
 
 ## CLI
 
@@ -18,17 +20,30 @@ astro-up sync
 # Scan for installed software
 astro-up scan
 
-# List all available packages
-astro-up list
+# Show all packages, installed, or outdated
+astro-up show all
+astro-up show installed
+astro-up show outdated
 
-# Check for updates
-astro-up check
+# Search the catalog
+astro-up search "plate solver"
 
-# Update everything
+# Install a package
+astro-up install nina-app
+
+# Update a specific package or all at once
+astro-up update nina-app
 astro-up update --all
 
-# Update a specific package
-astro-up update nina-app
+# Show available backups
+astro-up show backups
+
+# Check or initialize config
+astro-up config show
+astro-up config init
+
+# Self-update Astro-Up itself
+astro-up self-update
 ```
 
 All CLI commands support `--json` for machine-readable output.
@@ -36,7 +51,8 @@ All CLI commands support `--json` for machine-readable output.
 ## What Happens During an Update
 
 1. Astro-Up checks the catalog for the latest version
-2. If an update is available, it downloads the installer with SHA-256 verification
-3. Your configuration is backed up automatically
-4. The installer runs silently (or interactively, if configured)
-5. Detection re-runs to verify the new version is installed
+2. Downloads the installer with SHA-256 verification
+3. Backs up your configuration automatically
+4. Runs the installer silently (or interactively if configured)
+5. Re-runs detection to verify the new version is installed
+6. Records the result in operation history

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -1,66 +1,54 @@
 # Troubleshooting
 
+## Elevation Failures
+
+**UAC prompt not appearing**: Astro-Up elevates the installer process via `ShellExecuteEx` with `runas`. If UAC is disabled via Group Policy, installers requiring elevation will fail. Either enable UAC or run Astro-Up itself as administrator.
+
+**Elevation denied**: When you click "No" on the UAC prompt, the installer returns a cancellation exit code. Astro-Up reports this as a failed operation. Re-run and accept the prompt.
+
+**`elevation = "self"` packages**: These installers trigger their own UAC. If they fail silently, the installer may not support the silent switches in the manifest. Try interactive mode: `astro-up install <package> --yes` (uses interactive switches).
+
 ## Version Detection
 
-### Software is installed but Astro-Up doesn't detect it
+**Version shows 1.0.0 or 0.0.0**: The installer wrote a placeholder version to the registry or PE header. Run `astro-up scan` after the software has been launched once -- many applications update their version info on first run.
 
-Astro-Up detects software through Windows Registry, PE file headers, ASCOM profiles, and known paths. If detection fails:
+**Software installed but not detected**: Check `astro-up show <package-id>` to confirm it is in the catalog. Portable installations without registry entries need a `pe_file` or `file_exists` detection method in the manifest. If the manifest lacks a `[detection]` section, the lifecycle test workflow discovers one automatically.
 
-1. Confirm the software is in the catalog (`astro-up list`)
-2. Some software registers differently depending on install method (MSI vs EXE vs ZIP)
-3. Portable installations may not create registry entries
-4. The package may not have a detection config yet — check if there's an open [lifecycle test](https://github.com/nightwatch-astro/astro-up-manifests/actions) for it
+**False "update available"**: Version format mismatch between detected version and catalog version. For example, registry reports `3.1.0.2008` but the catalog has `3.1.0`. Report at [astro-up-manifests issues](https://github.com/nightwatch-astro/astro-up-manifests/issues) -- the fix is adding `version_regex` to normalize the format.
 
-### Wrong version detected
+## Asset Selection
 
-Some vendors store version numbers inconsistently between the registry and the executable. Please [report it](https://github.com/nightwatch-astro/astro-up-manifests/issues) if you see the wrong version.
+**"Asset selection cancelled"**: The package has multiple download assets (e.g., 32-bit vs 64-bit, qt5 vs qt6). In non-interactive mode or when no selector is provided, the first asset is picked automatically. In the GUI, a dialog prompts you to choose.
 
-## Updates
+## Catalog
 
-### Installer fails silently
+**Catalog not refreshing**: The catalog has a TTL (default 24h). Force with `astro-up catalog refresh`. If the catalog file is corrupted (integrity check fails), delete it from `%APPDATA%\nightwatch\astro-up\data\` and re-sync.
 
-Silent installation arguments vary by vendor. If an update fails:
+**Catalog schema unsupported**: Your astro-up version is older than the catalog. Update astro-up: `astro-up self-update`.
 
-1. Try running the update with `--interactive` to see the installer UI
-2. Check if the software requires admin privileges
-3. Check if another instance of the software is running (Astro-Up warns about blocking processes)
+## Downloads
 
-### Download fails
+**Download fails**: Downloads are resumable -- re-run the command and it continues from where it stopped. Check proxy settings (`network.proxy`) if behind a firewall.
 
-- Verify your internet connection
-- Some vendor download links expire or change — try syncing the catalog: `astro-up sync --force`
-- Check **Settings > Network** for proxy or timeout issues
-
-## Backups
-
-### Restore doesn't fix the issue
-
-Backups cover configuration files (profiles, settings, equipment configs) but not the application itself. If an update broke the software:
-
-1. Restore the backup from the Backup view or `astro-up restore <package>`
-2. Manually reinstall the previous version from the vendor's website
-
-### Backup paths are empty
-
-Some software doesn't create config files until first run. If you've never launched the software, there's nothing to back up.
+**Slow downloads**: Set a speed limit with `network.download_speed_limit` if you need to cap bandwidth during imaging sessions.
 
 ## General
 
 ### Verbose output
 
 ```sh
-astro-up --verbose check
+astro-up --verbose scan
 ```
 
 ### Log file
 
-Enable file logging in **Settings > Logging** or set `log_to_file = true` in `config.toml`. Logs are written to `%APPDATA%\nightwatch\astro-up\logs\`.
+Enable file logging: set `logging.log_to_file` to `true` via `astro-up config`. Logs are written to `%APPDATA%\nightwatch\astro-up\data\logs\`. Old logs are pruned after `logging.max_age_days` (default 365).
 
 ### Reporting issues
 
-When reporting a bug, include:
-- The command you ran (with `--verbose` output)
+Include with your bug report:
+- The command you ran with `--verbose` output
 - Your Windows version
-- Which software was affected
+- Which package was affected
 
 File issues at [github.com/nightwatch-astro/astro-up/issues](https://github.com/nightwatch-astro/astro-up/issues).

--- a/docs/guide/what-is-astro-up.md
+++ b/docs/guide/what-is-astro-up.md
@@ -1,40 +1,41 @@
 # What is Astro-Up?
 
-Astro-Up is a purpose-built software manager for astrophotography on Windows. It handles the complete lifecycle of your imaging software — detection, installation, updates, and backup — from a single GUI or CLI.
+Astro-Up is a software manager for astrophotography on Windows. It detects, installs, updates, and backs up your imaging software from a single app.
 
 ## The Problem
 
-Setting up an astrophotography imaging PC means installing dozens of applications, drivers, and tools from different vendors. Keeping everything updated requires visiting multiple websites, checking version numbers, and running installers manually. Whether your imaging PC is a permanent observatory setup or a portable rig for dark sites, managing software across all those vendors is tedious and error-prone.
+Setting up an astrophotography PC means installing dozens of applications, drivers, and tools from different vendors. Keeping everything updated requires visiting multiple websites, checking version numbers, and running installers manually. Whether your PC lives in an observatory or travels to dark sites, managing all that software is tedious and error-prone.
 
 ## What Astro-Up Does
 
-- **Detect** installed versions of applications, drivers, and tools automatically
-- **Browse** a curated catalog of 90+ astrophotography packages
-- **Install** new software with verified downloads and silent installers
-- **Update** everything with one click or command
+- **Detect** installed software using 9 methods (registry, PE headers, ASCOM, WMI, driver store, and more)
+- **Browse** a curated catalog of astrophotography packages
+- **Install** new software with verified downloads and silent or interactive installers
+- **Update** everything in one click, or queue multiple updates to run sequentially
 - **Back up** configuration before upgrading (profiles, settings, equipment configs)
-- **Track** star databases, ASCOM drivers, and resources
+- **Force reinstall** packages when something goes wrong
+- **Manage portable apps** with automatic Windows shortcut creation
 
-## Key Design Principles
+## Key Principles
 
-- **Windows-optimized** — dark theme, lightweight, fast on imaging PCs
-- **Config backup** — automatic backup before every upgrade
-- **Major version awareness** — warns before breaking upgrades
-- **Extensible** — TOML manifests make adding new software trivial
-- **Self-updating** — Astro-Up keeps itself up to date
+| Principle | Detail |
+|-----------|--------|
+| Windows-optimized | Dark theme, lightweight, fast on imaging PCs |
+| Config backup | Automatic backup before every upgrade |
+| Major version awareness | Warns before breaking upgrades |
+| Extensible catalog | TOML manifests make adding new software straightforward |
+| Self-updating | Astro-Up keeps itself current with markdown release notes |
 
 ## Architecture
-
-Astro-Up is built in Rust with a clean separation of concerns:
 
 | Layer | Technology | Purpose |
 |-------|-----------|---------|
 | `astro-up-core` | Rust library | Catalog, detection, download, install, config |
 | `astro-up-cli` | clap + ratatui | Terminal interface for power users |
-| `astro-up-gui` | Tauri v2 + Vue 3 | Desktop app with PrimeVue UI |
+| `astro-up-gui` | Tauri v2 + Vue 3 | Desktop app with PrimeVue dark theme |
 
-All business logic lives in `astro-up-core`. The CLI and GUI are thin adapters that share the same engine.
+All business logic lives in `astro-up-core`. The CLI and GUI are thin adapters sharing the same engine.
 
 ## Status
 
-Astro-Up is in active development. The core engine, CLI, and GUI are functional. The catalog is being populated with detection configs and download manifests via an [automated lifecycle testing pipeline](./lifecycle-testing.md).
+Astro-Up is in active development (v0.1.x). The core engine, CLI, and GUI are functional. The catalog is being populated with detection configs and download manifests via an [automated lifecycle testing pipeline](./lifecycle-testing.md).

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: home
 hero:
   name: Astro-Up
   text: Astrophotography Software Manager
-  tagline: Install, detect, and update imaging software on Windows — from one place.
+  tagline: Install, detect, and update imaging software on Windows -- from one place.
   actions:
     - theme: brand
       text: What is Astro-Up?
@@ -12,22 +12,20 @@ hero:
       text: View on GitHub
       link: https://github.com/nightwatch-astro/astro-up
 features:
-  - icon: "\U0001F4E6"
-    title: Curated Catalog
-    details: Pre-built catalog of 90+ astrophotography packages — ASCOM drivers, capture apps, plate solvers, planetariums, and more.
-  - icon: "\U0001F50D"
-    title: Auto-Detection
-    details: Scans your system for installed software via Windows registry, PE headers, ASCOM profiles, WMI, and known paths.
-  - icon: "\U0001F504"
-    title: Install & Update
-    details: Download, verify, and install software silently or interactively. Keep everything up to date with one click or command.
-  - icon: "\U0001F4BE"
-    title: Safe Backups
-    details: Automatic configuration backup before every upgrade — profiles, settings, and equipment configs are protected.
-  - icon: "\U0001F5A5\uFE0F"
-    title: GUI & CLI
-    details: Modern Tauri desktop app with Vue 3 frontend, plus a full-featured CLI for power users and automation.
-  - icon: "\u2699\uFE0F"
-    title: Configurable
-    details: Layered TOML configuration with sensible defaults. All settings adjustable from the GUI, CLI, or config file.
+  - title: Curated Catalog
+    details: Pre-built catalog of 90+ astrophotography packages -- ASCOM drivers, capture apps, plate solvers, planetariums, and more. Full-text search.
+  - title: Auto-Detection
+    details: Scans your system via Windows registry, PE headers, WMI, ASCOM profiles, driver store, and known paths. Fallback chains for reliable detection.
+  - title: Install and Update
+    details: Download, verify, and install software silently or interactively. Elevation handled automatically per package. Resumable downloads.
+  - title: Portable Apps
+    details: Packages using zip, portable, or download-only methods are extracted to a configurable folder with a Windows shortcut created automatically.
+  - title: Safe Backups
+    details: Automatic configuration backup before every upgrade -- profiles, settings, and equipment configs are protected. Restore with one command.
+  - title: Operation History
+    details: Every install, update, and backup is recorded in the operations ledger. Track what changed, when, and whether it succeeded.
+  - title: GUI and CLI
+    details: Tauri v2 desktop app with Vue 3 frontend, plus a full CLI for power users and scripted automation. Both share the same core engine.
+  - title: Configurable
+    details: SQLite-backed configuration with sensible defaults. All settings adjustable from the GUI, CLI, or directly in the database.
 ---

--- a/docs/reference/catalog.md
+++ b/docs/reference/catalog.md
@@ -1,51 +1,101 @@
 # Catalog Format
 
-The Astro-Up catalog is a pre-built SQLite database distributed via GitHub Releases. This page documents the catalog structure for contributors and advanced users.
+The catalog is a pre-compiled SQLite database containing all package definitions, detection configs, install configs, version history, and backup paths. Distributed via GitHub Releases and signed with [minisign](https://jedisct1.github.io/minisign/).
 
-## Distribution
+## Pipeline
 
-The catalog is maintained in the [astro-up-manifests](https://github.com/nightwatch-astro/astro-up-manifests) repository and published as `catalog.db` in GitHub Releases.
+```
+TOML manifests (astro-up-manifests repo)
+  -> Version checker scrapes latest versions from GitHub/websites
+  -> Compiler builds catalog.db from manifests + discovered versions
+  -> Signed with minisign
+  -> Published as GitHub Release artifact
+  -> Fetched by astro-up at runtime (ETag caching, TTL-based refresh)
+```
 
-## Database Schema
+## Database Tables
+
+### `meta`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `key` | TEXT PK | Metadata key (`schema_version`, `compiled_at`) |
+| `value` | TEXT | Metadata value |
 
 ### `packages`
 
-The main package table.
-
 | Column | Type | Description |
 |--------|------|-------------|
-| `id` | TEXT PK | Unique package identifier (e.g., `nina-app`) |
+| `id` | TEXT PK | Package ID (e.g., `nina-app`) |
+| `manifest_version` | INTEGER | Manifest schema version |
 | `name` | TEXT | Display name |
-| `category` | TEXT | Package category |
-| `publisher` | TEXT | Developer or organization |
-| `website` | TEXT | Official project URL |
 | `description` | TEXT | Short description |
+| `publisher` | TEXT | Developer or organization |
+| `homepage` | TEXT | Official project URL |
+| `category` | TEXT | `capture`, `guiding`, `platesolving`, `equipment`, `focusing`, `planetarium`, `viewers`, `prerequisites`, `usb`, `driver` |
+| `type` | TEXT | `application`, `driver`, `runtime`, `database`, `usb_driver`, `resource` |
+| `slug` | TEXT | URL-friendly short name |
 | `license` | TEXT | License identifier |
+| `tags` | TEXT (JSON) | Searchable tags array |
+| `aliases` | TEXT (JSON) | Alternative names array |
+| `dependencies` | TEXT (JSON) | Required package IDs array |
+| `icon_base64` | TEXT | Base64-encoded package icon |
 
-### `detection_configs`
+### `packages_fts`
 
-How to detect if a package is installed.
-
-| Column | Type | Description |
-|--------|------|-------------|
-| `package_id` | TEXT FK | References `packages.id` |
-| `method` | TEXT | Detection method: `registry`, `pe_header`, `known_path` |
-| `config` | TEXT (JSON) | Method-specific detection parameters |
+FTS5 virtual table for full-text search across name, description, tags, aliases, publisher.
 
 ### `versions`
 
-Known versions with download information.
+| Column | Type | Description |
+|--------|------|-------------|
+| `package_id` | TEXT FK | References `packages.id` |
+| `version` | TEXT | Version string |
+| `url` | TEXT | Primary download URL |
+| `sha256` | TEXT | SHA-256 checksum |
+| `discovered_at` | TEXT | ISO 8601 discovery timestamp |
+| `release_notes_url` | TEXT | Changelog URL |
+| `pre_release` | INTEGER | 1 if pre-release |
+| `assets` | TEXT (JSON) | Array of `{name, url, size}` for multi-asset releases |
+
+### `detection`
 
 | Column | Type | Description |
 |--------|------|-------------|
 | `package_id` | TEXT FK | References `packages.id` |
-| `version` | TEXT | Version string (semver when possible) |
-| `download_url` | TEXT | Installer download URL |
-| `sha256` | TEXT | SHA-256 checksum of the installer |
-| `release_date` | TEXT | ISO 8601 release date |
-| `installer_type` | TEXT | `exe`, `msi`, `zip` |
-| `silent_args` | TEXT | Arguments for silent installation |
+| `method` | TEXT | `registry`, `pe_file`, `wmi`, `wmi_apps`, `driver_store`, `ascom_profile`, `file_exists`, `config_file`, `ledger` |
+| `file_path` | TEXT | PE/file path for file-based detection |
+| `registry_key` | TEXT | Registry key path |
+| `registry_value` | TEXT | Registry value name |
+| `version_regex` | TEXT | Regex for extracting version from text |
+| `product_code` | TEXT | MSI product GUID |
+| `upgrade_code` | TEXT | MSI upgrade GUID |
+| `inf_provider` | TEXT | Driver INF provider name |
+| `device_class` | TEXT | Driver device class |
+| `inf_name` | TEXT | Driver INF filename |
+| `fallback_config` | TEXT (JSON) | Recursive `DetectionConfig` for fallback chain |
 
-## Contributing
+### `install`
 
-To add a new package to the catalog, see the [astro-up-manifests](https://github.com/nightwatch-astro/astro-up-manifests) repository for contribution guidelines.
+| Column | Type | Description |
+|--------|------|-------------|
+| `package_id` | TEXT FK | References `packages.id` |
+| `method` | TEXT | `exe`, `msi`, `inno_setup`, `nsis`, `wix`, `burn`, `zip`, `portable`, `download_only` |
+| `scope` | TEXT | `machine`, `user`, `either` |
+| `elevation` | TEXT | `required`, `prohibited`, `self` |
+| `switches` | TEXT (JSON) | `{silent, interactive, log, install_dir}` |
+| `exit_codes` | TEXT (JSON) | Map of exit code to known meaning |
+| `success_codes` | TEXT (JSON) | Array of non-zero success codes |
+| `zip_wrapped` | INTEGER | 1 if download is a zip containing the installer |
+| `zip_inner_path` | TEXT | Subfolder inside zip to find installer |
+
+### `backup`
+
+| Column | Type | Description |
+|--------|------|-------------|
+| `package_id` | TEXT FK | References `packages.id` |
+| `config_paths` | TEXT (JSON) | Array of paths to back up (supports `$LOCALAPPDATA`, `$APPDATA` variables) |
+
+## Source Repository
+
+TOML manifests are maintained in [nightwatch-astro/astro-up-manifests](https://github.com/nightwatch-astro/astro-up-manifests). See [Adding Manifests](/guide/adding-manifests) for the manifest format.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,63 +1,55 @@
-# CLI Commands
-
-The `astro-up` CLI provides all functionality available in the GUI, plus automation-friendly features like JSON output.
-
-Full documentation: [nightwatch-astro.github.io/astro-up](https://nightwatch-astro.github.io/astro-up/)
-
-## Global Options
+# CLI Reference
 
 ```
 astro-up [OPTIONS] <COMMAND>
-
-Options:
-  --config <PATH>       Path to config file
-  --log-level <LEVEL>   Override log level (error, warn, info, debug, trace)
-  --json                Output in JSON format
-  -v, --verbose         Increase verbosity
-  -q, --quiet           Suppress non-essential output
-  -h, --help            Print help
-  -V, --version         Print version
 ```
+
+## Global Flags
+
+| Flag | Short | Description |
+|------|-------|-------------|
+| `--json` | | Output as JSON (for scripting) |
+| `--verbose` | `-v` | Show debug output |
+| `--quiet` | `-q` | Suppress non-error output |
+| `--config <PATH>` | | Path to config database |
 
 ## Commands
 
-### `sync`
+### `catalog sync`
 
-Synchronize the software catalog.
+Sync the catalog if cache is stale.
 
 ```sh
-astro-up sync           # Sync if cache is stale
-astro-up sync --force   # Force re-download
+astro-up catalog sync
+```
+
+### `catalog refresh`
+
+Force re-download the catalog regardless of TTL.
+
+```sh
+astro-up catalog refresh
 ```
 
 ### `scan`
 
-Scan the system for installed astrophotography software.
+Scan the system for installed astrophotography software. Uses WMI enumeration, then per-package detection chains (registry, PE headers, ASCOM profiles, known paths, driver store).
 
 ```sh
-astro-up scan           # Scan and display results
-astro-up scan --json    # Output as JSON
+astro-up scan
 ```
 
-### `list` / `show`
+### `show`
 
-List packages from the catalog.
+Show software status. Without arguments, lists all catalog packages.
 
 ```sh
-astro-up list                    # All packages
+astro-up show                    # All packages
 astro-up show installed          # Installed only
-astro-up show outdated           # Packages with updates
-astro-up show backups nina-app   # Backups for a package
-astro-up list --json             # JSON output
-```
-
-### `check`
-
-Check installed packages for available updates.
-
-```sh
-astro-up check          # Check all
-astro-up check nina-app # Check specific
+astro-up show outdated           # Packages with available updates
+astro-up show backups            # All backups
+astro-up show backups nina-app   # Backups for a specific package
+astro-up show nina-app           # Detail view for a package
 ```
 
 ### `install`
@@ -65,63 +57,102 @@ astro-up check nina-app # Check specific
 Download and install a package.
 
 ```sh
-astro-up install nina-app                # Silent install
-astro-up install nina-app --interactive  # Show installer UI
+astro-up install nina-app                # Install (interactive by default)
+astro-up install nina-app --dry-run      # Preview only
+astro-up install nina-app -y             # Skip confirmation
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--dry-run` | Show what would be installed without executing |
+| `-y, --yes` | Skip confirmation prompt |
 
 ### `update`
 
 Update installed packages.
 
 ```sh
-astro-up update nina-app   # Update specific
-astro-up update --all      # Update all
+astro-up update nina-app               # Update one package
+astro-up update --all                  # Update all outdated packages
+astro-up update --all --dry-run        # Preview all updates
+astro-up update nina-app --allow-major # Allow major version jumps
+astro-up update nina-app -y            # Skip confirmation
+```
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Update all outdated packages |
+| `--dry-run` | Show plan without executing |
+| `--allow-major` | Allow updates across major versions |
+| `-y, --yes` | Skip confirmation prompt |
+
+### `search`
+
+Full-text search across package names, descriptions, tags, aliases, and publishers.
+
+```sh
+astro-up search "plate solver"
 ```
 
 ### `backup`
 
-Manage backups.
+Create a configuration backup for a package.
 
 ```sh
-astro-up backup nina-app   # Back up a package
-astro-up backup --list     # List backups
+astro-up backup nina-app
 ```
 
 ### `restore`
 
-Restore from a backup.
+Restore a package from a backup.
 
 ```sh
-astro-up restore nina-app  # Restore latest
+astro-up restore nina-app                   # Restore latest backup
+astro-up restore nina-app --path backup.zip # Restore specific file
+astro-up restore nina-app -y                # Skip confirmation
 ```
+
+| Flag | Description |
+|------|-------------|
+| `--path <FILE>` | Restore from a specific backup file |
+| `-y, --yes` | Skip confirmation prompt |
 
 ### `config`
 
-View or modify configuration.
+Manage configuration (SQLite-backed key-value store).
 
 ```sh
-astro-up config            # Show current config
-astro-up config --edit     # Open in editor
-```
-
-### `clear`
-
-Clear cached data.
-
-```sh
-astro-up clear --cache      # Clear catalog cache
-astro-up clear --downloads  # Clear downloaded installers
-astro-up clear --all        # Clear everything
+astro-up config init    # Generate default config
+astro-up config show    # Show effective configuration
 ```
 
 ### `self-update`
 
-Update Astro-Up itself.
+Update astro-up itself.
 
 ```sh
-astro-up self-update           # Check and install
-astro-up self-update --dry-run # Check only
+astro-up self-update            # Check and install update
+astro-up self-update --dry-run  # Check only
 ```
+
+### `lifecycle-test`
+
+Run a full lifecycle test for a package (download, install, detect, uninstall). Used by CI to validate manifests.
+
+```sh
+astro-up lifecycle-test nina-app --manifest-path ./manifests
+astro-up lifecycle-test nina-app --manifest-path ./manifests --dry-run
+astro-up lifecycle-test nina-app --manifest-path ./manifests --version 3.1.2
+```
+
+| Flag | Description |
+|------|-------------|
+| `--manifest-path <DIR>` | Path to manifests repo checkout (required) |
+| `--version <VER>` | Specific version to test (default: latest) |
+| `--install-dir <DIR>` | Install directory for download-only packages |
+| `--catalog-path <FILE>` | Path to compiled catalog.db for version resolution |
+| `--dry-run` | Download and probe only, skip install/uninstall |
+| `--report-file <FILE>` | Write JSON report to file |
 
 ## Exit Codes
 

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -1,147 +1,104 @@
-# Configuration File Reference
+# Configuration Reference
 
-Complete reference for `config.toml`. All settings are also configurable from the **GUI Settings panel** and via **CLI flags**.
+## Storage
 
-See [Configuration Guide](/guide/configuration) for an overview.
+Configuration uses a SQLite dot-path key-value store in the application database. Not a TOML file.
 
-## File Location
+| Item | Value |
+|------|-------|
+| Database | `astro-up.db` |
+| Table | `config_settings` (key TEXT, value TEXT, updated_at TEXT) |
+| Location | `%APPDATA%\nightwatch\astro-up\data\` |
+| Access | `astro-up config show` / `astro-up config init` / GUI Settings |
+| Validation | [garde](https://github.com/jprochazk/garde) on load |
+| Duration format | [humantime](https://docs.rs/humantime/) -- `"30s"`, `"5m"`, `"1h"`, `"24h"`, `"7days"` |
 
-```
-%APPDATA%\nightwatch\astro-up\config.toml
-```
+Keys use dot-path notation (e.g., `ui.theme`, `network.proxy`). Only keys with non-default values are stored; missing keys resolve to their defaults.
 
-## Complete Example
+## `ui`
 
-```toml
-[ui]
-font_size = "medium"
-auto_scan_on_launch = true
-default_install_scope = "user"
-default_install_method = "silent"
-auto_check_updates = true
-check_interval = "12h"
-auto_notify_updates = true
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `ui.theme` | `system` \| `dark` \| `light` | `system` | Color theme |
+| `ui.font_size` | `small` \| `medium` \| `large` | `medium` | UI font size |
+| `ui.auto_scan_on_launch` | bool | `false` | Scan for installed software on startup |
+| `ui.scan_interval` | `manual` \| `on_startup` \| `hourly` \| `daily` \| `weekly` | `hourly` | Auto-scan frequency |
+| `ui.default_install_scope` | `user` \| `machine` | `user` | Default install scope |
+| `ui.default_install_method` | `silent` \| `interactive` | `interactive` | Default installer mode |
+| `ui.auto_check_updates` | bool | `true` | Periodically check for package updates |
+| `ui.check_interval` | duration | `"24h"` | How often to check for updates (min 1m) |
+| `ui.auto_notify_updates` | bool | `true` | Show notification when updates are found |
+| `ui.survey_threshold` | u32 | `3` | Successful operations before showing feedback survey |
 
-[catalog]
-url = "https://github.com/nightwatch-astro/astro-up-manifests/releases/latest/download/catalog.db"
-cache_ttl = "12h"
+## `startup`
 
-[network]
-connect_timeout = "10s"
-timeout = "30s"
-download_speed_limit = 0
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `startup.start_at_login` | bool | `false` | Launch at system startup |
+| `startup.start_minimized` | bool | `false` | Start minimized to tray |
+| `startup.minimize_to_tray_on_close` | bool | `false` | Minimize to tray on close |
 
-[backup_policy]
-scheduled_enabled = false
-schedule = "weekly"
-max_per_package = 5
-max_total_size_mb = 0
-max_age_days = 0
+## `catalog`
 
-[notifications]
-enabled = true
-display_duration = 5
-show_errors = true
-show_warnings = true
-show_update_available = true
-show_operation_complete = true
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `catalog.url` | string (URL) | GitHub Releases URL | Catalog database download URL |
+| `catalog.cache_ttl` | duration | `"24h"` | Time before re-syncing catalog |
 
-[log]
-level = "info"
-log_to_file = false
+## `network`
 
-[startup]
-start_at_login = false
-minimize_to_tray_on_close = true
-start_minimized = false
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `network.proxy` | string? | none | HTTP proxy URL |
+| `network.connect_timeout` | duration | `"10s"` | TCP connection timeout |
+| `network.timeout` | duration | `"30s"` | Full request timeout |
+| `network.user_agent` | string | `astro-up/{version}` | HTTP User-Agent header |
+| `network.download_speed_limit` | u64 | `0` | Max download speed bytes/sec (0 = unlimited) |
 
-[paths]
-download_dir = ""
-backup_dir = ""
-```
+## `backup_policy`
 
-## Field Reference
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `backup_policy.scheduled_enabled` | bool | `false` | Enable scheduled backups |
+| `backup_policy.schedule` | `daily` \| `weekly` \| `monthly` | `weekly` | Backup schedule |
+| `backup_policy.max_per_package` | u32 | `5` | Max backups kept per package |
+| `backup_policy.max_total_size_mb` | u32 | `0` | Max total backup size in MB (0 = unlimited) |
+| `backup_policy.max_age_days` | u32 | `0` | Delete backups older than N days (0 = never) |
 
-::: tip GUI Settings
-Every field below has a corresponding control in the GUI Settings panel. The table column shows which Settings tab contains it.
-:::
+## `notifications`
 
-### `[ui]`
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `notifications.enabled` | bool | `true` | Enable desktop notifications |
+| `notifications.display_duration` | u32 | `5` | Seconds before auto-dismiss |
+| `notifications.show_errors` | bool | `true` | Show error notifications |
+| `notifications.show_warnings` | bool | `true` | Show warning notifications |
+| `notifications.show_update_available` | bool | `true` | Show update available notifications |
+| `notifications.show_operation_complete` | bool | `true` | Show operation complete notifications |
 
-| Field | Type | Default | GUI tab | Description |
-|-------|------|---------|---------|-------------|
-| `font_size` | `"small"` \| `"medium"` \| `"large"` | `"medium"` | General | UI font size |
-| `auto_scan_on_launch` | bool | `true` | General | Scan for installed software on app start |
-| `default_install_scope` | `"user"` \| `"machine"` | `"user"` | General | Default install scope |
-| `default_install_method` | `"silent"` \| `"interactive"` | `"silent"` | General | Default installer mode |
-| `auto_check_updates` | bool | `true` | General | Periodically check for package updates |
-| `check_interval` | duration | `"12h"` | General | How often to check for updates |
-| `auto_notify_updates` | bool | `true` | General | Show notification when updates found |
+## `paths`
 
-### `[catalog]`
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `paths.download_dir` | path | app data dir | Downloaded installers directory |
+| `paths.cache_dir` | path | app data dir | Cache directory |
+| `paths.data_dir` | path | app data dir | Application data directory |
+| `paths.portable_apps_dir` | path | app data dir | Portable apps install directory |
+| `paths.keep_installers` | bool | `true` | Keep downloaded installers after install |
+| `paths.purge_installers_after_days` | u32 | `30` | Delete kept installers after N days |
 
-| Field | Type | Default | GUI tab | Description |
-|-------|------|---------|---------|-------------|
-| `url` | string | GitHub Releases URL | Catalog | Catalog database download URL |
-| `cache_ttl` | duration | `"12h"` | Catalog | How long before re-syncing |
+## `updates`
 
-### `[network]`
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `updates.auto_check` | bool | `true` | Auto-check for astro-up updates |
+| `updates.check_interval` | duration | `"24h"` | Self-update check interval (min 1m) |
 
-| Field | Type | Default | GUI tab | Description |
-|-------|------|---------|---------|-------------|
-| `proxy` | string? | none | Network | HTTP proxy URL |
-| `connect_timeout` | duration | `"10s"` | Network | TCP connection timeout |
-| `timeout` | duration | `"30s"` | Network | Full request timeout |
-| `download_speed_limit` | u64 | `0` | Network | Max download speed in bytes/sec (0 = unlimited) |
+## `logging`
 
-### `[backup_policy]`
-
-| Field | Type | Default | GUI tab | Description |
-|-------|------|---------|---------|-------------|
-| `scheduled_enabled` | bool | `false` | Backup | Enable scheduled backups |
-| `schedule` | `"daily"` \| `"weekly"` \| `"monthly"` | `"weekly"` | Backup | Backup schedule |
-| `max_per_package` | u32 | `5` | Backup | Max backups per package |
-| `max_total_size_mb` | u64 | `0` | Backup | Max total backup size in MB (0 = unlimited) |
-| `max_age_days` | u32 | `0` | Backup | Delete backups older than N days (0 = never) |
-
-### `[notifications]`
-
-| Field | Type | Default | GUI tab | Description |
-|-------|------|---------|---------|-------------|
-| `enabled` | bool | `true` | Notifications | Enable desktop notifications |
-| `display_duration` | u32 | `5` | Notifications | Seconds before auto-dismiss (0 = never) |
-| `show_errors` | bool | `true` | Notifications | Show error notifications |
-| `show_warnings` | bool | `true` | Notifications | Show warning notifications |
-| `show_update_available` | bool | `true` | Notifications | Show update notifications |
-| `show_operation_complete` | bool | `true` | Notifications | Show operation complete notifications |
-
-### `[log]`
-
-| Field | Type | Default | GUI tab | Description |
-|-------|------|---------|---------|-------------|
-| `level` | log level | `"info"` | Logging | Log level (error, warn, info, debug, trace) |
-| `log_to_file` | bool | `false` | Logging | Write logs to file |
-| `log_file` | string? | auto | Logging | Log file path (auto-set when enabled) |
-
-### `[startup]`
-
-| Field | Type | Default | GUI tab | Description |
-|-------|------|---------|---------|-------------|
-| `start_at_login` | bool | `false` | General | Launch at system startup |
-| `minimize_to_tray_on_close` | bool | `true` | General | Minimize to tray on close |
-| `start_minimized` | bool | `false` | General | Start minimized to tray |
-
-### `[paths]`
-
-| Field | Type | Default | GUI tab | Description |
-|-------|------|---------|---------|-------------|
-| `download_dir` | string | app data dir | Paths | Downloaded installers directory |
-| `backup_dir` | string | app data dir | Paths | Backup archive directory |
-
-## Duration Format
-
-Duration values use [humantime](https://docs.rs/humantime/) format: `"30s"`, `"5m"`, `"1h"`, `"12h"`, `"1day"`, `"7days"`.
-
-## Validation
-
-Configuration is validated on load using [garde](https://github.com/jprochazk/garde). Invalid values produce clear error messages with the field name and constraint that failed.
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `logging.level` | `error` \| `warn` \| `info` \| `debug` \| `trace` | `info` | Log level |
+| `logging.log_to_file` | bool | `false` | Write logs to file |
+| `logging.log_file` | path | auto | Log file path |
+| `logging.max_age_days` | u32 | `365` | Delete log files older than N days (0 = never) |

--- a/docs/reference/faq.md
+++ b/docs/reference/faq.md
@@ -4,50 +4,84 @@
 
 ### Does Astro-Up work on Linux or macOS?
 
-No. Astro-Up is Windows-only because the astrophotography software it manages (ASCOM drivers, N.I.N.A., SharpCap, etc.) is Windows-only. Detection uses Windows-specific methods (registry, PE files, ASCOM profiles, WMI).
+No. Astro-Up is Windows-only because the astrophotography software it manages (ASCOM drivers, N.I.N.A., SharpCap, etc.) is Windows-only. Detection uses Windows APIs (registry, PE headers, WMI, driver store).
 
 ### Does it work offline?
 
-Astro-Up requires internet access to sync the catalog and download installers. It caches the catalog locally so browsing and detection work offline after the first sync.
+Astro-Up requires internet to sync the catalog and download installers. After the first sync, browsing and detection work offline using the cached catalog.
 
 ### Can I use it on multiple imaging PCs?
 
-Yes. Each installation is independent — install Astro-Up on each PC and it detects what's installed locally. Configuration and backups are per-machine.
+Yes. Each installation is independent with its own config, catalog cache, and backups.
 
 ### Is it free?
 
-Yes. Astro-Up is free and open source under the Apache 2.0 license.
+Yes. Apache 2.0 license.
 
-## Software Catalog
+## Elevation and Permissions
 
-### How often is the catalog updated?
+### Why does Astro-Up ask for administrator access?
 
-The catalog is updated whenever new packages or detection configs are added to the [astro-up-manifests](https://github.com/nightwatch-astro/astro-up-manifests) repository. Version data is checked periodically by CI.
+Many installers (especially ASCOM drivers and device drivers) require admin privileges. Astro-Up requests elevation via Windows UAC only when the manifest declares `elevation = "required"`. User-scoped installs do not need elevation.
 
-### My software isn't in the catalog
+### Why not use sudo.exe?
 
-You can [request it](https://github.com/nightwatch-astro/astro-up-manifests/issues) or [add it yourself](/guide/adding-manifests).
+Windows `sudo.exe` (available since Windows 11 24H2) runs the entire process elevated. Astro-Up only elevates the child installer process via `ShellExecuteEx` with `runas`, keeping the main process unprivileged. This is safer and works on all supported Windows versions.
 
-### What are package IDs?
+### What does `elevation = "self"` mean?
 
-Each package has a unique ID using `vendor-product` convention (e.g., `nina-app`, `zwo-asi-camera-driver`). Use these in CLI commands. Browse the catalog in the GUI or via `astro-up list`.
+The installer handles its own elevation internally (triggers its own UAC prompt). Astro-Up launches it without elevation and lets it self-elevate.
 
-## Updates
+## Detection
 
-### What happens if an update breaks something?
+### Version shows 1.0.0 or 0.0.0 after install
 
-Astro-Up backs up your configuration before every update. Restore with the Backup view in the GUI or `astro-up restore <package>`. The backup covers config files — for the app itself, reinstall the previous version from the vendor.
+Some installers write a placeholder version to the registry or PE header. Run `astro-up scan` after the first launch of the software -- many applications update their version info on first run.
 
-### Can I skip a version?
+### Software is installed but not detected
 
-There's no explicit "skip" feature. Astro-Up shows the latest available version. If you don't want to update, simply don't run the update for that package.
+1. Confirm the software is in the catalog: `astro-up show <package-id>`
+2. Portable installations may not create registry entries -- the manifest may need a `file_exists` or `pe_file` detection method
+3. The package may not have a detection config yet -- check for open [lifecycle tests](https://github.com/nightwatch-astro/astro-up-manifests/actions)
+
+### False "update available"
+
+Version format mismatch between the detection source (registry, PE header) and the catalog version string. For example, registry shows `3.1.0.2008` while the catalog has `3.1.0`. Report these at [astro-up-manifests issues](https://github.com/nightwatch-astro/astro-up-manifests/issues) so the manifest can add a `version_regex` to normalize the format.
+
+## Portable Apps
+
+### What are portable apps?
+
+Packages with install method `portable` or `download_only` are extracted to `paths.portable_apps_dir` instead of running an installer. A Windows shortcut is created automatically. No registry changes or elevation needed.
+
+### Can I force a reinstall?
+
+Yes. Use `--allow-major` with update, or the engine supports `force_reinstall` via the GUI. This re-downloads and re-installs even when the version matches.
+
+## Catalog
+
+### Catalog not refreshing
+
+The catalog has a TTL (default 24h). Force a refresh with `astro-up catalog refresh` or use the re-download button in Settings.
+
+### Multiple download options for a package
+
+Some releases have multiple assets (e.g., Stellarium qt5 vs qt6). Astro-Up shows an asset selection dialog when multiple options exist. In non-interactive mode, the first asset is selected automatically.
+
+## Downloads
+
+### Download fails or stalls
+
+- Downloads support resume -- retry the command and it will continue from where it stopped
+- Check proxy settings: `astro-up config show` and look for `network.proxy`
+- Verify the download URL is still valid: `astro-up catalog refresh` to get fresh URLs
 
 ## Configuration
 
 ### Where are settings stored?
 
-All settings live in `%APPDATA%\nightwatch\astro-up\config.toml`. You can edit this file directly, use the GUI Settings panel, or use `astro-up config --edit`. See the [full reference](/reference/config).
+SQLite database at `%APPDATA%\nightwatch\astro-up\data\astro-up.db` in the `config_settings` table. See the [full reference](/reference/config).
 
 ### Can I use different settings per imaging PC?
 
-Yes. Each PC has its own config file. Settings are not synced between machines.
+Yes. Each PC has its own database. Settings are not synced between machines.


### PR DESCRIPTION
## Summary
Comprehensive docs rewrite for v0.1.36. 14 files, 654 insertions, 494 deletions.

## What changed
- All 9 detection methods documented (added WmiApps, Ledger, PE version_regex)
- All 9 install methods documented (added burn, portable, download_only)
- Elevation handling: ShellExecuteExW runas, proactive + reactive, job objects
- Config reference: SQLite storage, all 9 sections with every field
- Catalog reference: full 7-table schema, manifest pipeline, minisign signing
- CLI reference: all 11 commands with flags and exit codes
- New features: portable apps, force reinstall, asset selection, update queue
- Troubleshooting: elevation failures, PE placeholders, version format issues
- FAQ: UAC, sudo.exe removal, portable apps, force reinstall
- Adding manifests: complete field reference with real examples
