### PR TITLE
fix(ci): fix docs deploy pnpm 10 esbuild build scripts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,9 +36,7 @@ jobs:
           cache-dependency-path: docs/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm --dir docs install --frozen-lockfile
-        env:
-          PNPM_ALLOW_BUILDS: esbuild
+        run: cd docs && pnpm install --frozen-lockfile --config.onlyBuiltDependencies='["esbuild"]'
 
       - name: Build docs
         run: pnpm --dir docs build


### PR DESCRIPTION
Fix docs deploy: pnpm 10 blocks esbuild build scripts. Use `--config.onlyBuiltDependencies` instead of env var.
