### PR TITLE
fix(ci): allow esbuild build scripts in docs via package.json config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,7 +36,7 @@ jobs:
           cache-dependency-path: docs/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: cd docs && pnpm install --frozen-lockfile --config.onlyBuiltDependencies='["esbuild"]'
+        run: pnpm --dir docs install --frozen-lockfile
 
       - name: Build docs
         run: pnpm --dir docs build

--- a/docs/package.json
+++ b/docs/package.json
@@ -9,5 +9,8 @@
   },
   "devDependencies": {
     "vitepress": "^1"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": ["esbuild"]
   }
 }


### PR DESCRIPTION
Add `pnpm.onlyBuiltDependencies: ["esbuild"]` to docs/package.json. pnpm 10 blocks build scripts by default — CLI flags and env vars don't override this, only the package.json config does.
