### PR TITLE
fix(ci): use working-directory for docs pnpm to fix esbuild

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -36,10 +36,12 @@ jobs:
           cache-dependency-path: docs/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm --dir docs install --frozen-lockfile
+        working-directory: docs
+        run: pnpm install --frozen-lockfile
 
       - name: Build docs
-        run: pnpm --dir docs build
+        working-directory: docs
+        run: pnpm build
 
       - uses: actions/configure-pages@v6
 


### PR DESCRIPTION
Use `working-directory: docs` instead of `pnpm --dir docs`. The `--dir` flag may not properly resolve `.npmrc` for build script approval. `working-directory` ensures pnpm runs from the docs directory and reads its local `.npmrc`.
