### PR TITLE
fix(ci): pin docs pnpm to v9 to fix esbuild build scripts

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 10
+          version: 9
 
       - uses: actions/setup-node@v6.3.0
         with:


### PR DESCRIPTION
Pin docs pnpm to v9. pnpm v10 blocks all build scripts by default and none of the documented overrides (package.json `pnpm.onlyBuiltDependencies`, `.npmrc`, `--config`, env vars) work with `--frozen-lockfile`. pnpm v9 runs esbuild's postinstall without issue.
