### PR TITLE
fix(ci): unset CI and use --no-frozen-lockfile for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: pnpm/action-setup@v6
         with:
-          version: 9
+          version: 10
 
       - uses: actions/setup-node@v6.3.0
         with:
@@ -37,7 +37,9 @@ jobs:
 
       - name: Install dependencies
         working-directory: docs
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --no-frozen-lockfile
+        env:
+          CI: ""
 
       - name: Build docs
         working-directory: docs


### PR DESCRIPTION
Use `--no-frozen-lockfile` and unset `CI` env for docs install. pnpm v10 blocks build scripts in CI mode (`CI=true`) with `--frozen-lockfile` and ignores all override mechanisms. Unsetting `CI` allows the build script approval from `.npmrc`/`package.json` to take effect.
