### PR TITLE
fix(ci): bypass pnpm v10 build script blocking for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,9 +37,9 @@ jobs:
 
       - name: Install dependencies
         working-directory: docs
-        run: pnpm install --no-frozen-lockfile
-        env:
-          CI: ""
+        run: |
+          pnpm install --frozen-lockfile --ignore-scripts
+          node node_modules/esbuild/install.js
 
       - name: Build docs
         working-directory: docs


### PR DESCRIPTION
Bypass pnpm v10's build script blocking entirely: install with `--ignore-scripts` then manually run esbuild's `install.js` postinstall. No pnpm config, env vars, or version pinning needed.
