### PR TITLE
fix(ci): correct esbuild path in pnpm store for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,7 +39,7 @@ jobs:
         working-directory: docs
         run: |
           pnpm install --frozen-lockfile --ignore-scripts
-          node node_modules/esbuild/install.js
+          node $(find node_modules/.pnpm -path '*/esbuild/install.js' -print -quit)
 
       - name: Build docs
         working-directory: docs


### PR DESCRIPTION
Fix esbuild install.js path — pnpm stores it in `.pnpm/esbuild@version/node_modules/esbuild/`, not `node_modules/esbuild/`.
