### PR TITLE
fix(ci): use --prefer-frozen-lockfile for docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -37,7 +37,7 @@ jobs:
 
       - name: Install dependencies
         working-directory: docs
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --prefer-frozen-lockfile
 
       - name: Build docs
         working-directory: docs


### PR DESCRIPTION
Use `--prefer-frozen-lockfile` instead of `--frozen-lockfile`. The frozen flag makes pnpm v10 skip .npmrc build-script allowlist processing entirely. prefer-frozen still validates the lockfile but allows build scripts approved via .npmrc.
