### PR TITLE
ci: consolidate app-token onto shared release App

### DIFF
--- a/.github/workflows/lifecycle-test.yml
+++ b/.github/workflows/lifecycle-test.yml
@@ -41,8 +41,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.NIGHTWATCH_APP_ID }}
-          private-key: ${{ secrets.NIGHTWATCH_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           repositories: astro-up-manifests
 
       - uses: actions/checkout@v7
@@ -99,8 +99,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.NIGHTWATCH_APP_ID }}
-          private-key: ${{ secrets.NIGHTWATCH_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           repositories: astro-up-manifests
 
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,8 +52,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.NIGHTWATCH_APP_ID }}
-          private-key: ${{ secrets.NIGHTWATCH_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: googleapis/release-please-action@v5
         id: release


### PR DESCRIPTION
## Summary

- Retire the per-repo `NIGHTWATCH_APP_ID` / `NIGHTWATCH_APP_PRIVATE_KEY` secrets in favour of the org-wide shared release App.
- Every `actions/create-github-app-token` step now uses `vars.RELEASE_APP_CLIENT_ID` (variable) and `secrets.RELEASE_APP_PRIVATE_KEY`, which are already provisioned org-wide (visibility=all).
- Downstream `outputs.token` references and step IDs are unchanged.

## Files changed

| File | Steps updated |
|------|---------------|
| `.github/workflows/release.yml` | 1 — `Generate app token` in `release-please` job (line 53) |
| `.github/workflows/lifecycle-test.yml` | 2 — `Generate app token` in `prepare` job (line 42) and `test` job (line 99) |

## Post-merge cleanup

Once CI is green and this is merged, the repo-level (or org-level) `NIGHTWATCH_APP_ID` and `NIGHTWATCH_APP_PRIVATE_KEY` secrets can be removed if no other workflow references them.
