### PR TITLE
chore: exclude shell and tooling scaffolding from language stats

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,10 @@
 specs/** linguist-generated
 .specify/** linguist-generated
 .claude/** linguist-generated
+# Exclude shell scripts and agent/SpecKit tooling scaffolding from GitHub
+# language statistics (linguist) — small Rust crates otherwise report Shell
+# as the primary repository language.
+*.sh linguist-detectable=false
+.specify/** linguist-vendored
+.codex/** linguist-vendored
+.claude/** linguist-vendored


### PR DESCRIPTION
Excludes `*.sh` and agent/SpecKit tooling directories from linguist language statistics, matching the org-wide change applied to the other repos.