### PR TITLE
fix: store CLA signatures on unprotected branch, allowlist owner

### DIFF
--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -32,5 +32,5 @@ jobs:
         with:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
-          branch: "main"
-          allowlist: "bot*,dependabot*,renovate*,*[bot]*,sjorsr-release-bot*,nightwatch-astro-ci*"
+          branch: "cla-signatures"
+          allowlist: "srobroek,bot*,dependabot*,renovate*,*[bot]*,sjorsr-release-bot*,nightwatch-astro-ci*"


### PR DESCRIPTION
Future-proofs the CLA Assistant against branch protection on main: the action commits signatures to its configured branch, and per its own requirements that branch must not be protected, so signature storage moves to a dedicated cla-signatures branch. Also adds the repo owner (srobroek) to the allowlist so owner PRs never wait on a CLA signature. Matches prompting-press/prompting-press#320.