### PR TITLE
ci: attest build provenance for the CLI and installer

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,10 @@ jobs:
     needs: release-please
     if: needs.release-please.outputs.releases_created == 'true'
     runs-on: windows-latest
+    permissions:
+      contents: write # gh release upload + tauri-action's own uploads
+      id-token: write # OIDC identity that signs the attestation
+      attestations: write # publish the attestation to this repo
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v6
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
@@ -124,6 +128,7 @@ jobs:
         run: cargo binstall tauri-cli --version ^2 --no-confirm
 
       - name: Build Tauri app
+        id: tauri
         uses: tauri-apps/tauri-action@v0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -139,6 +144,54 @@ jobs:
           prerelease: false
           includeUpdaterJson: true
           updaterJsonPreferNsis: true
+
+      # Attest everything this job produced: the standalone CLI plus the Tauri bundles.
+      # Runs while the release is still a draft, so nothing is publicly downloadable
+      # before its provenance exists.
+      #
+      # tauri-action emits artifactPaths as a JSON ARRAY STRING (see its src/index.ts:
+      # `JSON.stringify(artifacts.map((a) => a.path))`), which actions/attest cannot
+      # consume directly — subject-path wants a newline-separated list. Convert it here
+      # rather than hardcoding bundle filenames, which carry the version and would drift
+      # on every release.
+      #
+      # This does NOT replace the Tauri updater signatures (.sig) that tauri-action
+      # produces: those are what the auto-updater checks against the app's embedded
+      # public key, offline and with no GitHub dependency. The attestation records which
+      # workflow run built the bytes, and verifying it requires reaching GitHub. Keep both.
+      - name: Collect artifact paths for attestation
+        id: subjects
+        shell: bash
+        env:
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+        run: |
+          # Bundles only: skip the .sig sidecars (signatures over the bundles, not
+          # artifacts in their own right) and latest.json (a pointer regenerated on every
+          # release, so a provenance claim over it ages out immediately).
+          bundles="$(printf '%s' "${ARTIFACT_PATHS:-[]}" |
+            jq -r '.[] | select(endswith(".sig") or endswith("latest.json") | not)')"
+
+          # Fail loud rather than attesting only the CLI. If tauri-action changes its
+          # output shape, an empty list here would leave the installer unattested while
+          # the job still went green — the release would look provenance-covered when the
+          # artifact users actually download was not.
+          if [ -z "$bundles" ]; then
+            echo "::error::no Tauri bundles found in artifactPaths; refusing to attest a partial artifact set"
+            echo "artifactPaths was: ${ARTIFACT_PATHS:-<unset>}"
+            exit 1
+          fi
+
+          {
+            echo 'paths<<SUBJECTS_EOF'
+            echo "astro-up-cli.exe"
+            echo "$bundles"
+            echo 'SUBJECTS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: ${{ steps.subjects.outputs.paths }}
 
   publish-release:
     name: Publish Release

--- a/README.md
+++ b/README.md
@@ -28,6 +28,24 @@ astro-up check         # Check for updates
 astro-up update --all  # Update everything
 ```
 
+### Verifying a download
+
+Every released binary and installer carries a GitHub build provenance attestation — a
+signed statement of which workflow run, at which commit, produced those exact bytes.
+Check one with the [GitHub CLI](https://cli.github.com/):
+
+```sh
+gh attestation verify Astro-Up_x64-setup.exe -R nightwatch-astro/astro-up
+gh attestation verify astro-up-cli.exe       -R nightwatch-astro/astro-up
+```
+
+Verification contacts GitHub, since the attestation is stored with the repository rather
+than alongside the download. Add `--format json` for the full predicate.
+
+This is separate from the `.sig` files in each release: those are Tauri updater
+signatures, checked by the app's own auto-updater against its embedded public key, and
+they work offline.
+
 ## Development
 
 ```sh


### PR DESCRIPTION
Adds [GitHub artifact attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations) to the release build, so the standalone CLI and the Tauri installer each carry a signed statement of which workflow run, at which commit, produced those exact bytes.

## What changed

`.github/workflows/release.yml` — the `build` job gains `id-token: write` + `attestations: write`, a step that collects the artifact paths, and an `actions/attest` step (SHA-pinned to `f7c74d2`, v4.2.0). `README.md` gains a "Verifying a download" section under Quick Start.

```console
$ gh attestation verify Astro-Up_x64-setup.exe -R nightwatch-astro/astro-up
$ gh attestation verify astro-up-cli.exe       -R nightwatch-astro/astro-up
```

## Why the attest step sits where it does

Inside `build`, after both the CLI and the Tauri bundles exist, and **while the release is still a draft** — `publish-release` only undrafts once `build` succeeds. So nothing becomes publicly downloadable before its provenance exists.

## The artifactPaths conversion

`tauri-action` emits `artifactPaths` as a **JSON array string**, not a newline-separated list. Confirmed in its source rather than inferred — `src/index.ts` does:

```js
core.setOutput('artifactPaths', JSON.stringify(artifacts.map((a) => a.path)))
```

`actions/attest`'s `subject-path` wants newlines, so a conversion step handles it. Doing it this way also avoids hardcoding bundle filenames, which carry the version and would drift on every release.

Two things are filtered out:

- **`.sig` sidecars** — signatures over the bundles, not artifacts in their own right.
- **`latest.json`** — a pointer regenerated on every release, so a provenance claim over it ages out immediately.

## It fails loud on an empty bundle list

If `tauri-action` ever changes its output shape, attesting only `astro-up-cli.exe` would leave the installer — the thing users actually download — uncovered, while the job still went green. The release would *look* provenance-covered when it was not. The step errors instead:

```
::error::no Tauri bundles found in artifactPaths; refusing to attest a partial artifact set
```

## This does not touch Tauri updater signing

The `.sig` files in each release are what the auto-updater checks against the app's embedded public key, offline and without contacting GitHub. This adds build provenance alongside them; neither replaces the other, and the README says so.

## Validation

- `actionlint` clean.
- The collect step's `jq` filter and its fail-loud branch were both exercised against realistic `artifactPaths` payloads (bundle + `.sig` + `latest.json`, and the empty case).
- `jq` with `shell: bash` on `windows-latest` is already established in this same workflow (line 33 reads the release-please manifest that way), so this adds no new runner dependency.
- Attestation needs GitHub OIDC and cannot be exercised locally, so **the first release after merge is the real proof** — worth watching that run.
